### PR TITLE
chore(flake/nixpkgs): `13e8d35b` -> `1f08a4df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1753489912,
-        "narHash": "sha256-uDCFHeXdRIgJpYmtcUxGEsZ+hYlLPBhR83fdU+vbC1s=",
+        "lastModified": 1753749649,
+        "narHash": "sha256-+jkEZxs7bfOKfBIk430K+tK9IvXlwzqQQnppC2ZKFj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13e8d35b7d6028b7198f8186bc0347c6abaa2701",
+        "rev": "1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`dcc19818`](https://github.com/NixOS/nixpkgs/commit/dcc198185311f430de40750c6c35ec8aa8cb1326) | `` python3Packages.buildstream-plugins: init at 2.4.0 ``                         |
| [`007eb35d`](https://github.com/NixOS/nixpkgs/commit/007eb35d91234f06047a627e74025cc93abf12ea) | `` nixos/tlsrpt: fix permissions to execute postdrop ``                          |
| [`c3246b01`](https://github.com/NixOS/nixpkgs/commit/c3246b01ba25b06c94ef946467af2203f59a381b) | `` nixos/tlsrpt: fix restart trigger ``                                          |
| [`6a90d84e`](https://github.com/NixOS/nixpkgs/commit/6a90d84e44cdb24afc7701e5c57fb8284443dae8) | `` nixos/tlsrpt: fix default postfix sendmail path ``                            |
| [`1f8c34b2`](https://github.com/NixOS/nixpkgs/commit/1f8c34b250fadc1c2b45ce38cac367a759f6b9d6) | `` sauerbraten: fix build ``                                                     |
| [`3e25ab90`](https://github.com/NixOS/nixpkgs/commit/3e25ab90e8b12255a3753925c05f39760fc85c79) | `` linux_xanmod_latest: 6.15.7 -> 6.15.8 ``                                      |
| [`f4203b33`](https://github.com/NixOS/nixpkgs/commit/f4203b335b687891f06e99d149ffe41e3c5f1889) | `` linux_xanmod: 6.12.39 -> 6.12.40 ``                                           |
| [`4b6268a3`](https://github.com/NixOS/nixpkgs/commit/4b6268a34bf5466c03900460817206e17b4e9564) | `` llvmPackages_git: 22.0.0-unstable-2025-07-20 -> 22.0.0-unstable-2025-07-28 `` |
| [`d7d22d94`](https://github.com/NixOS/nixpkgs/commit/d7d22d94832f6334ea499d27d8f189c3c201a29b) | `` linux/common-config: enable new 6.16 features ``                              |
| [`9eca2364`](https://github.com/NixOS/nixpkgs/commit/9eca2364358b84e1098f01057a5a99d08d001c3d) | `` linux_6_16: init at 6.16 ``                                                   |
| [`b210d55d`](https://github.com/NixOS/nixpkgs/commit/b210d55d48bf74ad8a8b8a206fd577c0836658fb) | `` nixos/lib/test-driver: try using XDG_RUNTIME_DIR if available ``              |
| [`a6335244`](https://github.com/NixOS/nixpkgs/commit/a63352447478ae47dc08d46e60cf5a90069605dc) | `` miniflux: 2.2.10 -> 2.2.11 ``                                                 |
| [`161d9aef`](https://github.com/NixOS/nixpkgs/commit/161d9aef5a82d6142423e89aa916d85e3221833d) | `` mmctl: 10.5.8 -> 10.5.9 ``                                                    |
| [`b4718edb`](https://github.com/NixOS/nixpkgs/commit/b4718edb45772f2bbc98fcfe96162f0d7fcd48c5) | `` ustreamer: 6.31 -> 6.39 ``                                                    |
| [`70db00a1`](https://github.com/NixOS/nixpkgs/commit/70db00a101a56b8b4b17d7eb3799054276c487fc) | `` flyctl: 0.3.157 -> 0.3.161 ``                                                 |
| [`50ce7782`](https://github.com/NixOS/nixpkgs/commit/50ce77821aa904620f687d40d3dd483995136af5) | `` buffer: 0.10.0 -> 0.10.1 ``                                                   |
| [`d3c139fb`](https://github.com/NixOS/nixpkgs/commit/d3c139fb56fff091a1670eac7dc495667dcea241) | `` rustfinity: 0.2.13 -> 0.2.14 ``                                               |
| [`7e805bc0`](https://github.com/NixOS/nixpkgs/commit/7e805bc0e2e19d9d0e0f085b78869052a357ebd0) | `` rustfinity: remove useFetchCargoVendor usages ``                              |
| [`f63032fc`](https://github.com/NixOS/nixpkgs/commit/f63032fced3c39803ec18690e759099f1561a3f6) | `` outline: 0.85.0 -> 0.85.1 ``                                                  |
| [`ebb3620e`](https://github.com/NixOS/nixpkgs/commit/ebb3620e761b8cfe59f47f4997326d45ef8a96d5) | `` installer/nixos-generate-config: remove broadcom_sta ``                       |
| [`3fae474b`](https://github.com/NixOS/nixpkgs/commit/3fae474b46b914cd3f5d43e7af0e2e3defda5b90) | `` vscode: 1.102.1 -> 1.102.2 ``                                                 |
| [`3856b699`](https://github.com/NixOS/nixpkgs/commit/3856b699f3221dce6285b6dfe3d49ca7edccaa86) | `` postfix-tlspol: adopt package and module ``                                   |
| [`c50fcdd3`](https://github.com/NixOS/nixpkgs/commit/c50fcdd3131231ee0ba17317a5eb220d6cbef048) | `` nixos/postfix-tlspol: only preset dns resolver with useLocalResolver ``       |
| [`cd303ff4`](https://github.com/NixOS/nixpkgs/commit/cd303ff41b155aaa0b19ac6309e83220b3e01bc0) | `` postfix-tlspol: 1.8.11 -> 1.8.12 ``                                           |
| [`b29b1ffc`](https://github.com/NixOS/nixpkgs/commit/b29b1ffc562000f332ca53d90286a84102acd05d) | `` postfix-tlspol: 1.8.10 -> 1.8.11 ``                                           |
| [`ead9bfd3`](https://github.com/NixOS/nixpkgs/commit/ead9bfd3cf341b1f768e0f44e4cca547c682deb5) | `` postfix-tlspol: 1.8.9 -> 1.8.10 ``                                            |
| [`482dc4fb`](https://github.com/NixOS/nixpkgs/commit/482dc4fbf6ff998c1992c10693100e372598e5c3) | `` mdp: 1.0.17 -> 1.0.18 ``                                                      |
| [`810f9d66`](https://github.com/NixOS/nixpkgs/commit/810f9d6654d1a300ca742b78e77e7a7803bb4394) | `` mdp: 1.0.15 -> 1.0.17 ``                                                      |
| [`9701a002`](https://github.com/NixOS/nixpkgs/commit/9701a002c667f6cb748273fd363ef09c360a384e) | `` rectangle: 0.88 -> 0.89 ``                                                    |
| [`09e53f29`](https://github.com/NixOS/nixpkgs/commit/09e53f298d34219e1a29953a4983e629b32367a6) | `` rectangle: 0.87 -> 0.88 ``                                                    |
| [`1d86f62e`](https://github.com/NixOS/nixpkgs/commit/1d86f62edf801b01f1f2e0d05448ab86058783bc) | `` phel: 0.18.0 -> 0.18.1 ``                                                     |
| [`e7d3191a`](https://github.com/NixOS/nixpkgs/commit/e7d3191a4e6418514699bef71404fecc5cbe7ce8) | `` phel: 0.17.0 -> 0.18.0 ``                                                     |
| [`74a469b1`](https://github.com/NixOS/nixpkgs/commit/74a469b1ddb795f372d4f51438918730f8774680) | `` phel: 0.16.1 -> 0.17.0 ``                                                     |
| [`b734585a`](https://github.com/NixOS/nixpkgs/commit/b734585a64a7948bd5b2375b224557209beb87e5) | `` vivaldi: 7.5.3735.54 -> 7.5.3735.56 ``                                        |
| [`62d10f27`](https://github.com/NixOS/nixpkgs/commit/62d10f27acdea605ce72dedd3fca4326b8bb83ac) | `` wdisplays: 1.1.1 -> 1.1.3 ``                                                  |
| [`77fe0156`](https://github.com/NixOS/nixpkgs/commit/77fe0156510777aea64c4326556a40f78d531a2e) | `` ubootRadxaZero3W: init ``                                                     |
| [`42a17f8a`](https://github.com/NixOS/nixpkgs/commit/42a17f8a4f77ea64e88b350fed39d42875a8b574) | `` immich: 1.135.3 -> 1.136.0 ``                                                 |
| [`ec0f3e3d`](https://github.com/NixOS/nixpkgs/commit/ec0f3e3d93d68ee6a1ad2839121bc3bfa234697f) | `` microsoft-edge: 138.0.3351.95 -> 138.0.3351.109 ``                            |
| [`b5ce7e8b`](https://github.com/NixOS/nixpkgs/commit/b5ce7e8be4312c01e19284eb9fcca7dd7fe8230a) | `` ed-odyssey-materials-helper: 2.178 -> 2.199 and fixes ``                      |
| [`a6dd04d2`](https://github.com/NixOS/nixpkgs/commit/a6dd04d237ac8bf079c86dc4eb02589b8fe02db1) | `` elastic: 0.1.6 -> 0.1.9 ``                                                    |
| [`1f7c3f60`](https://github.com/NixOS/nixpkgs/commit/1f7c3f60c26c62ed70042d32fae49a006d6a84a5) | `` bustle: 0.11.0 -> 0.12.0 ``                                                   |
| [`b7ca8825`](https://github.com/NixOS/nixpkgs/commit/b7ca8825a9dc85008a3e593bc17aa3d24b872154) | `` slack: 4.44.65 -> 4.45.64 ``                                                  |
| [`b59b26cf`](https://github.com/NixOS/nixpkgs/commit/b59b26cfec4f02b768a3b35177110ea91d686c55) | `` thunderbird-latest-bin-unwrapped: 140.0.1 -> 141.0 ``                         |
| [`451ed55d`](https://github.com/NixOS/nixpkgs/commit/451ed55d3a78e9d20b87b91a13c43b6a974dbd55) | `` kubectl: 1.33.2 -> 1.33.3 ``                                                  |
| [`46444338`](https://github.com/NixOS/nixpkgs/commit/46444338ac14ccbace9ec46cdf10b56e19ac0b78) | `` kubectl: 1.33.1 -> 1.33.2 ``                                                  |
| [`625d7a4f`](https://github.com/NixOS/nixpkgs/commit/625d7a4f962e51de684f5362a3c1f6db712912db) | `` kubernetes: 1.33.0 -> 1.33.1 ``                                               |
| [`216496c7`](https://github.com/NixOS/nixpkgs/commit/216496c7b14e0f09d933cebdf301f4693c577f1a) | `` forgejo: 12.0.0 -> 12.0.1 ``                                                  |
| [`58f94672`](https://github.com/NixOS/nixpkgs/commit/58f9467253c9cfd66061bc296a384f2d3b7f0fdd) | `` homepage-dashboard: dashboard-icons: 2025-01-06 -> 2025-07-11 ``              |
| [`abf57e52`](https://github.com/NixOS/nixpkgs/commit/abf57e52904b9323bd9891b6c128e14945e8e844) | `` homepage-dashboard: fix enableLocalIcons = true build ``                      |
| [`da40ac7d`](https://github.com/NixOS/nixpkgs/commit/da40ac7d807ae1b658f6bc545647900f266d9b5a) | `` filebrowser: 2.36.0 -> 2.40.1 ``                                              |
| [`e0adac3c`](https://github.com/NixOS/nixpkgs/commit/e0adac3c5c12a5783cdd2aea3480356b9f1aca2b) | `` ghost-cli: 1.27.0 -> 1.27.1 ``                                                |
| [`cda6299e`](https://github.com/NixOS/nixpkgs/commit/cda6299e3b7dc710e4abb0ecd202477eea9d5580) | `` pixelflasher: 8.0.1.0 -> 8.0.3.1 ``                                           |
| [`e867ce87`](https://github.com/NixOS/nixpkgs/commit/e867ce876e6f80529ddf1a5dc54dcbd9d0513f6b) | `` nextcloud-spreed-signaling: init at 2.0.3 (#392811) ``                        |
| [`23c6adf8`](https://github.com/NixOS/nixpkgs/commit/23c6adf8039d90493f39e1755f8c80108f4017b1) | `` weechat-unwrapped: 4.6.3 -> 4.7.0 ``                                          |
| [`ee8333f7`](https://github.com/NixOS/nixpkgs/commit/ee8333f7cbd11697e6ab6d109a4423fb7218887c) | `` gerrit: 3.11.3 -> 3.11.4 ``                                                   |