### PR TITLE
chore(flake/chaotic): `8f2cff66` -> `a37025e6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -11,11 +11,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1754090351,
-        "narHash": "sha256-eUl2wW/D+4+SuKcIsbFJVLKhP5xF64LF+TNXQ77YJLg=",
+        "lastModified": 1754315603,
+        "narHash": "sha256-JsW4E7aOm3EYTWgDKJWLSPqJYAqAFq+tBD6GlKlS+nw=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "8f2cff668b87f6291558611f9e3a56589bf1a53c",
+        "rev": "a37025e61f964cd5057129150444b8fdbe0dfd88",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753983724,
-        "narHash": "sha256-2vlAOJv4lBrE+P1uOGhZ1symyjXTRdn/mz0tZ6faQcg=",
+        "lastModified": 1754174776,
+        "narHash": "sha256-Sp3FRM6xNwNtGzYH/HByjzJYHSQvwsW+lDMMZNF43PQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7035020a507ed616e2b20c61491ae3eaa8e5462c",
+        "rev": "e6e2f43a62b7dbc8aa8b1adb7101b0d8b9395445",
         "type": "github"
       },
       "original": {
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754024609,
-        "narHash": "sha256-9egicw/unEymBuR+vliF3MmZTDEBSF2oE4Z7a+4zssI=",
+        "lastModified": 1754110197,
+        "narHash": "sha256-N7GWK2084EsNdwzwg6FCIgMrSau1WwzxGSNdPHx5Tak=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "e5cf232a0f03e5d3f22ce0cae41e1d59771c32f3",
+        "rev": "04ce5c103eb621220d69102bc0ee27c3abd89204",
         "type": "github"
       },
       "original": {
@@ -257,11 +257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754016903,
-        "narHash": "sha256-mRB5OOx7H5kFwW8Qtc/7dO3qHsBQtZ/eYQEj93/Noo8=",
+        "lastModified": 1754189623,
+        "narHash": "sha256-fstu5eb30UYwsxow0aQqkzxNxGn80UZjyehQVNVHuBk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "ddd488184f01603b712ddbb6dc9fe0b8447eb7fc",
+        "rev": "c582ff7f0d8a7ea689ae836dfb1773f1814f472a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                         |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`a37025e6`](https://github.com/chaotic-cx/nyx/commit/a37025e61f964cd5057129150444b8fdbe0dfd88) | `` failures: update x86_64-linux ``             |
| [`2a2701c7`](https://github.com/chaotic-cx/nyx/commit/2a2701c791455c303e3f138a06ceee2203959ea6) | `` zfs_cachyos: bypass non-overridable check `` |
| [`4611c23e`](https://github.com/chaotic-cx/nyx/commit/4611c23eec9d5043831cb0a4b66e50c51ffb8923) | `` nixpkgs: bump to 20250804 ``                 |
| [`a6462b68`](https://github.com/chaotic-cx/nyx/commit/a6462b687f6194b39aa3f6526890cebad1852812) | `` nixpkgs: bump to 20250804 ``                 |
| [`8456c9ee`](https://github.com/chaotic-cx/nyx/commit/8456c9ee811787540b33890120476a7ea8de0ec0) | `` Bump 20250803-1 (#1137) ``                   |
| [`7d636c20`](https://github.com/chaotic-cx/nyx/commit/7d636c20793e6a60565ef649a5d9a68c617faf97) | `` failures: update aarch64-darwin ``           |
| [`8720e8a8`](https://github.com/chaotic-cx/nyx/commit/8720e8a8e63b33e5fb8241734b4ccb6aa622f49f) | `` Bump 20250802-1 (#1136) ``                   |
| [`2c5b1758`](https://github.com/chaotic-cx/nyx/commit/2c5b1758f8dfef743e469aa78013e96e31a1921d) | `` failures: update aarch64-linux ``            |