### PR TITLE
chore(flake/nixpkgs): `59e69648` -> `ce01daeb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -188,11 +188,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754028485,
-        "narHash": "sha256-IiiXB3BDTi6UqzAZcf2S797hWEPCRZOwyNThJIYhUfk=",
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59e69648d345d6e8fef86158c555730fa12af9de",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`b2ae7791`](https://github.com/NixOS/nixpkgs/commit/b2ae779108f4b613d384a00ee3e64dd3d6a9cdff) | `` psitransfer: 2.2.0 -> 2.3.0 ``                                            |
| [`1e0c7832`](https://github.com/NixOS/nixpkgs/commit/1e0c78320687bfb79f5b93e72082098d308dcd94) | `` psitransfer: add updateScript ``                                          |
| [`c2ec0664`](https://github.com/NixOS/nixpkgs/commit/c2ec0664dbf5e57b54fbeaebb8bb31668e9b2f09) | `` psitransfer: add meta.changelog ``                                        |
| [`ccdc5d96`](https://github.com/NixOS/nixpkgs/commit/ccdc5d9692481ec93fa49d9699a52f3ff3acc74a) | `` psitransfer: use tag in fetchFromGitHub ``                                |
| [`f7edcc11`](https://github.com/NixOS/nixpkgs/commit/f7edcc11957960987422eef1b9d29268a02b37bf) | `` psitransfer: use finalAttrs pattern ``                                    |
| [`a3bf1ae4`](https://github.com/NixOS/nixpkgs/commit/a3bf1ae457c5c3b4bf03c2d1f6cfd8d4f913c600) | `` nordic: remove broken symlinks ``                                         |
| [`ea5ec312`](https://github.com/NixOS/nixpkgs/commit/ea5ec312a167d62857f53ad574d92c82c853f229) | `` nordic: 2.2.0-unstable-2025-03-21 -> 2.2.0-unstable-2025-05-05 ``         |
| [`f270dba0`](https://github.com/NixOS/nixpkgs/commit/f270dba066b5d1dab4a13309a3ef490639c2e8ea) | `` php84: 8.4.10 -> 8.4.11 ``                                                |
| [`9ea312ff`](https://github.com/NixOS/nixpkgs/commit/9ea312ff1c9ac4649c1b03443ef92a57ab639e2e) | `` grafana: 12.0.2+security-01 -> 12.0.3 ``                                  |
| [`a2818d9e`](https://github.com/NixOS/nixpkgs/commit/a2818d9eb6b5c2907ffff5628c48c7163b0eaa18) | `` postgresqlPackages.pg_net: 0.19.3 -> 0.19.4 ``                            |
| [`19cf815d`](https://github.com/NixOS/nixpkgs/commit/19cf815dd4eaa88e178fa705c77efe060a8ae97d) | `` php83: 8.3.23 -> 8.3.24 ``                                                |
| [`f43edb8d`](https://github.com/NixOS/nixpkgs/commit/f43edb8d263bb72be59579be167867e8146fcc94) | `` postgresqlPackages.pgsql-http: 1.6.3 -> 1.7.0 ``                          |
| [`dda27a7d`](https://github.com/NixOS/nixpkgs/commit/dda27a7d18da81d8e92effa31a28e354b5d61287) | `` firefox-esr: migrate to 140 ESR ``                                        |
| [`ef25968c`](https://github.com/NixOS/nixpkgs/commit/ef25968c8a9f26f33e3d5fe7740ea19ba12fad80) | `` mozillavpn: 2.29.0 → 2.30.0 ``                                            |
| [`38ffa481`](https://github.com/NixOS/nixpkgs/commit/38ffa481f21afb6c23c1d909c0893eecff628469) | `` cjdns-tools: remove usage of with lib ``                                  |
| [`5422ce50`](https://github.com/NixOS/nixpkgs/commit/5422ce505834d27a0fba9ea38afc2c9201f3d51d) | `` cjdns-tools: enable darwin support ``                                     |
| [`366c8776`](https://github.com/NixOS/nixpkgs/commit/366c877654dbcda0d4d6767360712f6625c449e2) | `` cjdns: enable darwin support ``                                           |
| [`581e9508`](https://github.com/NixOS/nixpkgs/commit/581e95089f09d54bda2818234a99035dc62484b9) | `` cjdns: remove usage of with lib ``                                        |
| [`afc55247`](https://github.com/NixOS/nixpkgs/commit/afc55247219a54542546a05e54146ea7caa553e0) | `` nixos/cjdns: update for cjdns 22.1 compatibility ``                       |
| [`1aecbd9d`](https://github.com/NixOS/nixpkgs/commit/1aecbd9daac22ed6c390572378a108290f0436e1) | `` cjdns: 21.4 -> 22.1 ``                                                    |
| [`0f737795`](https://github.com/NixOS/nixpkgs/commit/0f737795114429940eaa13a4e486f71925037a18) | `` cjdns: bring changes from master ``                                       |
| [`2103b52d`](https://github.com/NixOS/nixpkgs/commit/2103b52dd485f167b3b59f072934fbedbf276802) | `` asterisk: expose version 22 ``                                            |
| [`eceab9fb`](https://github.com/NixOS/nixpkgs/commit/eceab9fb00a6cd8c559dc4b37f66a5718ef088b3) | `` asterisk: update dependencies ``                                          |
| [`fcba09cd`](https://github.com/NixOS/nixpkgs/commit/fcba09cd98f649e1c94206741c25fcc552c99198) | `` asterisk: fix regex escapes in update script ``                           |
| [`e7091093`](https://github.com/NixOS/nixpkgs/commit/e7091093dfb7071aa86a8cb4cdb87ea6838d3bd7) | `` asterisk: 18.26.1 -> 18.26.2, 20.11.1 -> 20.15.0, 22.1.1 -> 22.5.0 ``     |
| [`3de2f5b6`](https://github.com/NixOS/nixpkgs/commit/3de2f5b64e943dba988aa5db59c490a654a20675) | `` linux_xanmod_latest: 6.15.8 -> 6.15.9 ``                                  |
| [`7405b152`](https://github.com/NixOS/nixpkgs/commit/7405b152f34900f1b1ccb71ccb15992f9d2f7374) | `` linux_xanmod: 6.12.40 -> 6.12.41 ``                                       |
| [`4d448bbc`](https://github.com/NixOS/nixpkgs/commit/4d448bbc65dbb2539cb086d5960c4ba9891bf9d1) | `` ludusavi: add rclone dependency ``                                        |
| [`b37b3a02`](https://github.com/NixOS/nixpkgs/commit/b37b3a02d06581019c324c2094cb751a2a1c22a5) | `` qtgreet: 2.0.3.95 -> 2.0.4 ``                                             |
| [`f253d037`](https://github.com/NixOS/nixpkgs/commit/f253d0375ce68ffa636e43710adcdb51df871f37) | `` microsoft-edge: 138.0.3351.109 -> 138.0.3351.121 ``                       |
| [`ad21bbbe`](https://github.com/NixOS/nixpkgs/commit/ad21bbbe385d408176f88ff15633f72ae3c2a481) | `` element-desktop: 1.11.106 -> 1.11.108 ``                                  |
| [`a10f6dbd`](https://github.com/NixOS/nixpkgs/commit/a10f6dbd21b8a7148f394a7b51296615dc1548ef) | `` element-web-unwrapped: 1.11.106 -> 1.11.108 ``                            |
| [`7292c629`](https://github.com/NixOS/nixpkgs/commit/7292c629cd7e76cc09d6d5f292e8c57b67d838ab) | `` dua: 2.30.1 -> 2.31.0 ``                                                  |
| [`4ada3349`](https://github.com/NixOS/nixpkgs/commit/4ada334940ad0a407b8ba653fe7ea0c4892bb10e) | `` dua: 2.29.4 -> 2.30.1 ``                                                  |
| [`a163bf4f`](https://github.com/NixOS/nixpkgs/commit/a163bf4fa7a56ab7ab5ea61fe9dabf1d05384238) | `` pnpm: 10.13.1 -> 10.14.0 ``                                               |
| [`dcd0ee65`](https://github.com/NixOS/nixpkgs/commit/dcd0ee655b5d3047267cbf88b9786ad98d7c5195) | `` opencode: 0.3.110 -> 0.3.112 ``                                           |
| [`0df28ec3`](https://github.com/NixOS/nixpkgs/commit/0df28ec39fa7298e0fa03b17acd7573748f8e11f) | `` opencode: fix missing `tree-sitter-htesyypn.node` module runtime error `` |
| [`580f5368`](https://github.com/NixOS/nixpkgs/commit/580f5368af5ed2b568c44e1842d8e2fc219de310) | `` keycloak.plugins.keycloak-restrict-client-auth: 24.0.0 -> 26.1.0 ``       |
| [`42eb51f9`](https://github.com/NixOS/nixpkgs/commit/42eb51f96f85dd6786691ab98fb5898f85509a07) | `` thunderbird-128: 128.12.0esr -> 128.13.0esr (#428534) ``                  |
| [`03d34781`](https://github.com/NixOS/nixpkgs/commit/03d3478185b4c12b3ac1a6426b082fbda0097b3d) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.182 -> 0.0.184 ``               |
| [`ab3d831c`](https://github.com/NixOS/nixpkgs/commit/ab3d831ca49671679284c532fb5239b916604899) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.829 -> 0.0.836 ``            |
| [`6e888e8c`](https://github.com/NixOS/nixpkgs/commit/6e888e8ceae2ff174777cbd1d32d5d073c50b998) | `` pkgsCross.aarch64-darwin.discord: 0.0.354 -> 0.0.355 ``                   |
| [`96ec2b28`](https://github.com/NixOS/nixpkgs/commit/96ec2b285df91c55c95eeb20a8e497824e2b3123) | `` discord-ptb: 0.0.152 -> 0.0.154 ``                                        |
| [`51c8e507`](https://github.com/NixOS/nixpkgs/commit/51c8e5070a50a81dea02fede91f27b5f10b5678c) | `` discord-canary: 0.0.723 -> 0.0.730 ``                                     |
| [`fe6d0f34`](https://github.com/NixOS/nixpkgs/commit/fe6d0f34fad0fb54afd76b5e7b4e692c501594f4) | `` discord: 0.0.102 -> 0.0.103 ``                                            |
| [`49e76d4e`](https://github.com/NixOS/nixpkgs/commit/49e76d4e080e680b5e87151b3e63b331755a2590) | `` linux_6_6: 6.6.100 -> 6.6.101 ``                                          |
| [`fbbaafd2`](https://github.com/NixOS/nixpkgs/commit/fbbaafd2ef239187238988f95f10847bc9ad4033) | `` linux_6_12: 6.12.40 -> 6.12.41 ``                                         |
| [`02549e2b`](https://github.com/NixOS/nixpkgs/commit/02549e2b78baccd372704b87093539dac8d7e26e) | `` linux_6_15: 6.15.8 -> 6.15.9 ``                                           |
| [`16d0a7d0`](https://github.com/NixOS/nixpkgs/commit/16d0a7d0c6fa24419795d64f442e904d4605d178) | `` webkitgtk_6_0: 2.48.3 → 2.48.5 ``                                         |
| [`8070bf89`](https://github.com/NixOS/nixpkgs/commit/8070bf89060cc0fe8fd50a1178876790e126151e) | `` opencode: 0.3.85 -> 0.3.110 ``                                            |
| [`f9b8af5c`](https://github.com/NixOS/nixpkgs/commit/f9b8af5c75e4931004681cde44ebc51bb0fc005f) | `` models-dev: 0-unstable-2025-07-31 -> 0-unstable-2025-08-01 ``             |
| [`e3bf731f`](https://github.com/NixOS/nixpkgs/commit/e3bf731faf015377fa54071a54a24e0c889aa2bf) | `` asus-wmi-screenpad-ctl: init at 1.0.0 ``                                  |
| [`90168302`](https://github.com/NixOS/nixpkgs/commit/9016830251e15dd71d621acd1e17e2b6e8615ee6) | `` vkquake: add meta.license ``                                              |
| [`4e3b5d72`](https://github.com/NixOS/nixpkgs/commit/4e3b5d72bdf323aa5edbed4ed572caa8b645d8ad) | `` squid: remove knownVulnerabilities for 7.0+ ``                            |
| [`45f7b160`](https://github.com/NixOS/nixpkgs/commit/45f7b1605b23965483d8dd007393e5ebced516bb) | `` dust: 1.2.2 -> 1.2.3 ``                                                   |
| [`7b3ca855`](https://github.com/NixOS/nixpkgs/commit/7b3ca855085ce2c74f757f215cd109f1e49c2101) | `` pymol: modernize ``                                                       |
| [`450f1590`](https://github.com/NixOS/nixpkgs/commit/450f15909ed7bfdc0b21c9356be5166691a35888) | `` pymol: fix build ``                                                       |
| [`2452f861`](https://github.com/NixOS/nixpkgs/commit/2452f86197da36954f8a3712d6fceef16603e492) | `` nexusmods-app: 0.13.4 -> 0.14.3 ``                                        |
| [`1d5d9e64`](https://github.com/NixOS/nixpkgs/commit/1d5d9e6424bb269404c856463daacf6110aebc44) | `` tokyonight-gtk-theme: 0-unstable-2025-07-21 -> 0-unstable-2025-07-28 ``   |
| [`434cdded`](https://github.com/NixOS/nixpkgs/commit/434cddede7c844f57693ab3d80077baa98865884) | `` linuxKernel.packages.linux*.v4l2loopback: 0.15.0 -> 0.15.1 ``             |
| [`4efc4d38`](https://github.com/NixOS/nixpkgs/commit/4efc4d386ca06b51737a65c1cc53172254f45130) | `` linuxPackages.acer-wmi-battery: init at 0.1.0-unstable-2025-04-24 ``      |
| [`320ebadf`](https://github.com/NixOS/nixpkgs/commit/320ebadffec649762a041b087e6f008098b7afe9) | `` zoom-us: reintroduce `unset QT_PLUGIN_PATH` ``                            |
| [`47c32074`](https://github.com/NixOS/nixpkgs/commit/47c320747b654f345ae685365bb59dfd25ed87fa) | `` komikku: 1.82.0 -> 1.83.0 ``                                              |
| [`307988f3`](https://github.com/NixOS/nixpkgs/commit/307988f3ea3ac3df797b008998ce208d5ed9d8fb) | `` linuxKernel.kernels.linux_zen: 6.15.7 -> 6.15.8 ``                        |
| [`257320d6`](https://github.com/NixOS/nixpkgs/commit/257320d61c1e730525621aa5cb2973c5627e68d7) | `` forge-sparks: 0.4.0 -> 1.0.1 ``                                           |
| [`ae451421`](https://github.com/NixOS/nixpkgs/commit/ae451421738e1c3b824370614f209c9fb29ffab6) | `` librewolf-bin-unwrapped: 140.0.4-1 -> 141.0-1 ``                          |
| [`77f29ae1`](https://github.com/NixOS/nixpkgs/commit/77f29ae1745433d5eaf1c297591721c4d0ea5998) | `` librewolf-bin-unwrapped: 140.0.2-1 -> 140.0.4-1 ``                        |
| [`fb48ff4d`](https://github.com/NixOS/nixpkgs/commit/fb48ff4d9f971c02e27edc6bd92013f8422c1bed) | `` librewolf-bin-unwrapped: 139.0.4-1 -> 140.0.2-1 ``                        |
| [`335e728d`](https://github.com/NixOS/nixpkgs/commit/335e728d192a23f06512ac94be9f962d47641daf) | `` ansible: add jmespath by default ``                                       |
| [`c451cbe2`](https://github.com/NixOS/nixpkgs/commit/c451cbe29796db1fc762e4e0ae6269cf3b0ce4d9) | `` ansible: add extraPackages option ``                                      |
| [`6c8b9347`](https://github.com/NixOS/nixpkgs/commit/6c8b9347b418eea2c59082a32c80fee2e43591c2) | `` knot-dns: 3.4.7 -> 3.4.8 ``                                               |
| [`13df1220`](https://github.com/NixOS/nixpkgs/commit/13df1220cc694b8f10e104f065967ac896b1f614) | `` nixos/qbittorrent: add maintainer undefined-landmark ``                   |
| [`ff6b4e99`](https://github.com/NixOS/nixpkgs/commit/ff6b4e99e50ce9a9ea936e370027c902691dfd5f) | `` maintainers: add undefined-landmark ``                                    |
| [`3849dd70`](https://github.com/NixOS/nixpkgs/commit/3849dd705ec0e81e3122412c751738ca0c491cfe) | `` nixos/qbittorrent: init service module ``                                 |
| [`4fd3a59d`](https://github.com/NixOS/nixpkgs/commit/4fd3a59d8aec2367b6fb6f0b1c4b3839b87a4a80) | `` nixos/kanidm: accept originUrls following rfc8252 (#428204) ``            |
| [`e559ef4c`](https://github.com/NixOS/nixpkgs/commit/e559ef4c8d47b0eb321b059a4b5215dd17ffbe48) | `` tui-journal: Remove openssl dependency ``                                 |
| [`389bc8e5`](https://github.com/NixOS/nixpkgs/commit/389bc8e5f6abe20cb32a95c20a2b345533f47b32) | `` tui-journal: 0.16.0 -> 0.16.1 ``                                          |
| [`137d1af7`](https://github.com/NixOS/nixpkgs/commit/137d1af725ca3ecf169c70fd1fff09aa52fa5568) | `` tui-journal: Remove useFetchCargoVendor ``                                |
| [`028fb932`](https://github.com/NixOS/nixpkgs/commit/028fb9326e06d124eeebaa2447b49fa151f29603) | `` tui-journal: 0.15.0 -> 0.16.0 ``                                          |
| [`a0135cfa`](https://github.com/NixOS/nixpkgs/commit/a0135cfa6641d6a54f7d2902a14b9cf09ba263b3) | `` thunderbird-latest-unwrapped: 140.0.1 -> 141.0 ``                         |
| [`3e92a370`](https://github.com/NixOS/nixpkgs/commit/3e92a3702c7c1c0164011dfdeddc415313b61f3f) | `` devenv: 1.8 -> 1.8.1 ``                                                   |
| [`5249ce35`](https://github.com/NixOS/nixpkgs/commit/5249ce352264dc3742276367799fb558714cca4b) | `` gruvbox-gtk-theme: 0-unstable-2025-04-24 -> 0-unstable-2025-07-21 ``      |
| [`8c385b39`](https://github.com/NixOS/nixpkgs/commit/8c385b3971d23239802c0d1efe6f8ed13ab5fd6d) | `` nightfox-gtk-theme: 0-unstable-2025-04-24 -> 0-unstable-2025-07-21 ``     |
| [`f3b02021`](https://github.com/NixOS/nixpkgs/commit/f3b020219dd45dfcb310f34a9b8cbfb8c448a5ac) | `` vscode-extensions.apollographql.vscode-apollo: 2.5.6 -> 2.6.2 ``          |
| [`6ee8b700`](https://github.com/NixOS/nixpkgs/commit/6ee8b7003e289d2aba1c4df8c82c3490d1d1b585) | `` tailscale: disable flaky test ``                                          |
| [`65c9be48`](https://github.com/NixOS/nixpkgs/commit/65c9be4873c28849513fe4311feb27a7389a8960) | `` tailscale: re-enable `packet_filter_test.go` ``                           |
| [`566b08a4`](https://github.com/NixOS/nixpkgs/commit/566b08a4a294905bb39bbe95eef3f021148c1f58) | `` tailscale: remove unused fetchpatch ``                                    |
| [`2cd1c3af`](https://github.com/NixOS/nixpkgs/commit/2cd1c3afa1600eab993b29bc87952ab98807d5e6) | `` tailscale: disable packet_filter_test ``                                  |
| [`de2dbdce`](https://github.com/NixOS/nixpkgs/commit/de2dbdcebbeb8e3bd0e7a4a4f028c3d57fb94284) | `` tailscale: disable timeout taildrop tests ``                              |
| [`76b696bb`](https://github.com/NixOS/nixpkgs/commit/76b696bb84dcc26e3d8b0c68ce99f5de97fe5e57) | `` tailscale: skip one more flaky test ``                                    |