### PR TITLE
chore(flake/nur): `4de6ec34` -> `59ac4b2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754319480,
-        "narHash": "sha256-Q2sQCiGrQ80bPdD2b8xrjKXEr+frwDP7Oa5LtgRqiy8=",
+        "lastModified": 1754340213,
+        "narHash": "sha256-bwzT5Z2Bh62KrNhl5XUslnHidoK5HHak3i4mU4qQY8U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4de6ec34385c2fdd449989fc3751586caaf1dc12",
+        "rev": "59ac4b2ec963142b5704f2e1546e2dcfafc01a18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59ac4b2e`](https://github.com/nix-community/NUR/commit/59ac4b2ec963142b5704f2e1546e2dcfafc01a18) | `` automatic update `` |
| [`44c7f334`](https://github.com/nix-community/NUR/commit/44c7f3346c03a7be8daec3000f1439d599fc25e4) | `` automatic update `` |
| [`6fedd841`](https://github.com/nix-community/NUR/commit/6fedd8415b6d9e0334b5856590f28b2d7ad5eb6f) | `` automatic update `` |
| [`4f349574`](https://github.com/nix-community/NUR/commit/4f3495740e94b46f26224d69c7bca99c4636a9e4) | `` automatic update `` |
| [`6888874b`](https://github.com/nix-community/NUR/commit/6888874b6564776d5589b6f0b077402bf89b49d6) | `` automatic update `` |