### PR TITLE
chore(flake/nur): `59ac4b2e` -> `77af0b88`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754340213,
-        "narHash": "sha256-bwzT5Z2Bh62KrNhl5XUslnHidoK5HHak3i4mU4qQY8U=",
+        "lastModified": 1754366617,
+        "narHash": "sha256-8/ePOmqZIujxHIz47TSAxA4muAbJjhdomuwKDF6f9WI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "59ac4b2ec963142b5704f2e1546e2dcfafc01a18",
+        "rev": "77af0b886b6834477508b1687025a85a022195c4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`77af0b88`](https://github.com/nix-community/NUR/commit/77af0b886b6834477508b1687025a85a022195c4) | `` automatic update `` |
| [`020814ff`](https://github.com/nix-community/NUR/commit/020814ffe4a59ae6505da99b4d1f8974b079064b) | `` automatic update `` |
| [`24615e65`](https://github.com/nix-community/NUR/commit/24615e65ddbb87121696af57341e502d7e3bab1d) | `` automatic update `` |
| [`86b81f35`](https://github.com/nix-community/NUR/commit/86b81f35cd5960cdaaca2f163d8a01d1d30c8d7c) | `` automatic update `` |
| [`d2ef31d5`](https://github.com/nix-community/NUR/commit/d2ef31d5f3c8741ef3b337805d4af02a861cce1c) | `` automatic update `` |