### PR TITLE
chore(flake/nur): `77af0b88` -> `b87a1f25`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754366617,
-        "narHash": "sha256-8/ePOmqZIujxHIz47TSAxA4muAbJjhdomuwKDF6f9WI=",
+        "lastModified": 1754381907,
+        "narHash": "sha256-r3yk278jntenZBETNbxzQx3fVrExNupLiXG7bwtYbKo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "77af0b886b6834477508b1687025a85a022195c4",
+        "rev": "b87a1f254b94afde7576c0f8d9cb08c8c4c86813",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b87a1f25`](https://github.com/nix-community/NUR/commit/b87a1f254b94afde7576c0f8d9cb08c8c4c86813) | `` automatic update `` |
| [`127ab730`](https://github.com/nix-community/NUR/commit/127ab73088f6bac90002d029917ae221843ef746) | `` automatic update `` |
| [`2e290232`](https://github.com/nix-community/NUR/commit/2e290232463dc31bde2dad9abbb57de4cf69b08b) | `` automatic update `` |
| [`47a3ab22`](https://github.com/nix-community/NUR/commit/47a3ab2237d8d4ae00972961ee2c4c990086c950) | `` automatic update `` |
| [`7537c779`](https://github.com/nix-community/NUR/commit/7537c779788743ed67a029bfcc35b44e2b94b8c7) | `` automatic update `` |
| [`221eaea9`](https://github.com/nix-community/NUR/commit/221eaea9fd0cdc439ef6e81a9cf905e79ccc5b16) | `` automatic update `` |
| [`b0898632`](https://github.com/nix-community/NUR/commit/b089863231a27da84bc4f6be888912e0b4f34d85) | `` automatic update `` |