### PR TITLE
chore(flake/nur): `b87a1f25` -> `0ac1d444`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754381907,
-        "narHash": "sha256-r3yk278jntenZBETNbxzQx3fVrExNupLiXG7bwtYbKo=",
+        "lastModified": 1754400538,
+        "narHash": "sha256-fQdv+DdjbHhU/mlmmnDdKz5EJl9u3PGL7yOZmO+haf8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b87a1f254b94afde7576c0f8d9cb08c8c4c86813",
+        "rev": "0ac1d444081e97cc13e4ca4c3bf270ec9cfbe417",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0ac1d444`](https://github.com/nix-community/NUR/commit/0ac1d444081e97cc13e4ca4c3bf270ec9cfbe417) | `` automatic update `` |
| [`c5e3486d`](https://github.com/nix-community/NUR/commit/c5e3486deac19e38334299561921d476a15bffae) | `` automatic update `` |
| [`e4a75065`](https://github.com/nix-community/NUR/commit/e4a750657f01d5760b0d83a359b20209cd9342bf) | `` automatic update `` |
| [`4dbdd033`](https://github.com/nix-community/NUR/commit/4dbdd033a969d9b760027e70123cef914a9665e2) | `` automatic update `` |
| [`ece10aaf`](https://github.com/nix-community/NUR/commit/ece10aaf47a202e1524551deb6e72c2528671cf6) | `` automatic update `` |