### PR TITLE
chore(flake/nur): `0ac1d444` -> `c5b4e11a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754400538,
-        "narHash": "sha256-fQdv+DdjbHhU/mlmmnDdKz5EJl9u3PGL7yOZmO+haf8=",
+        "lastModified": 1754412379,
+        "narHash": "sha256-tSV0giEo+dn1WWUJpyo4TtNVz8ABjn/fJEojSP0i2oQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "0ac1d444081e97cc13e4ca4c3bf270ec9cfbe417",
+        "rev": "c5b4e11aed12c12a2abc0f2c84d6745548769230",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5b4e11a`](https://github.com/nix-community/NUR/commit/c5b4e11aed12c12a2abc0f2c84d6745548769230) | `` automatic update `` |
| [`2409585c`](https://github.com/nix-community/NUR/commit/2409585cb172e9a2328d9d4e64b51de8649dcaf3) | `` automatic update `` |
| [`0b4eed7f`](https://github.com/nix-community/NUR/commit/0b4eed7fa8aa8b78b6b2671185eecbf51dbcbd66) | `` automatic update `` |