### PR TITLE
chore(flake/nur): `c5b4e11a` -> `860a8770`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754412379,
-        "narHash": "sha256-tSV0giEo+dn1WWUJpyo4TtNVz8ABjn/fJEojSP0i2oQ=",
+        "lastModified": 1754426420,
+        "narHash": "sha256-LXxgtGcub0h8w/K2WbuWBzTYoUHCs8vHwoL2xWI+oro=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5b4e11aed12c12a2abc0f2c84d6745548769230",
+        "rev": "860a87705d4de350afc1372d5c280063001c063a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`860a8770`](https://github.com/nix-community/NUR/commit/860a87705d4de350afc1372d5c280063001c063a) | `` automatic update `` |
| [`faea73f5`](https://github.com/nix-community/NUR/commit/faea73f55df041fbcfd494989f22f301eafb26f9) | `` automatic update `` |
| [`27f48a20`](https://github.com/nix-community/NUR/commit/27f48a209fbf0d5c16781cf3180d77a7c0808461) | `` automatic update `` |
| [`9817af5f`](https://github.com/nix-community/NUR/commit/9817af5f151e75144ef32d657f55eaf116a2f5d6) | `` automatic update `` |