### PR TITLE
chore(flake/nur): `860a8770` -> `a43e846b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754426420,
-        "narHash": "sha256-LXxgtGcub0h8w/K2WbuWBzTYoUHCs8vHwoL2xWI+oro=",
+        "lastModified": 1754450928,
+        "narHash": "sha256-uBIIc8yV1zjuTRaVcSu9Cc+Ol5hsdehNWYn3CBFxsbw=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "860a87705d4de350afc1372d5c280063001c063a",
+        "rev": "a43e846bc9d5d144c2e5b3737a528b2fd78b836e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a43e846b`](https://github.com/nix-community/NUR/commit/a43e846bc9d5d144c2e5b3737a528b2fd78b836e) | `` automatic update `` |
| [`1141d998`](https://github.com/nix-community/NUR/commit/1141d9988632a8e1dc6451a9e0e5eddd57bdedde) | `` automatic update `` |
| [`4fcbb42f`](https://github.com/nix-community/NUR/commit/4fcbb42f9696a850b55481ded21c8dab51ed3af5) | `` automatic update `` |