### PR TITLE
chore(flake/nur): `a43e846b` -> `ed69ef7f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754450928,
-        "narHash": "sha256-uBIIc8yV1zjuTRaVcSu9Cc+Ol5hsdehNWYn3CBFxsbw=",
+        "lastModified": 1754456526,
+        "narHash": "sha256-DDb+1Ybk5oyyaqGYHoG6APyok+L7MsW0IHz48aUyrPI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a43e846bc9d5d144c2e5b3737a528b2fd78b836e",
+        "rev": "ed69ef7f5f2dc4d576a71c43bf004d28cdc5b1d1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ed69ef7f`](https://github.com/nix-community/NUR/commit/ed69ef7f5f2dc4d576a71c43bf004d28cdc5b1d1) | `` automatic update `` |
| [`f21a7640`](https://github.com/nix-community/NUR/commit/f21a76407e92cc5cfa2b567b53bf66f3ca6e1a10) | `` automatic update `` |
| [`e3a1715b`](https://github.com/nix-community/NUR/commit/e3a1715b85680818bd03daca0f0232d9ac957119) | `` automatic update `` |
| [`3bbf5daf`](https://github.com/nix-community/NUR/commit/3bbf5daf45315e3f52781f4233caab55fb5244f3) | `` automatic update `` |