### PR TITLE
chore(flake/nur): `ed69ef7f` -> `61e48174`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754456526,
-        "narHash": "sha256-DDb+1Ybk5oyyaqGYHoG6APyok+L7MsW0IHz48aUyrPI=",
+        "lastModified": 1754470884,
+        "narHash": "sha256-SZHEM6poGpccZD+vBtTM6NSDw27w26IVbkJYMvv2FqE=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ed69ef7f5f2dc4d576a71c43bf004d28cdc5b1d1",
+        "rev": "61e4817406656985e9536abf6453f7b623b838f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`61e48174`](https://github.com/nix-community/NUR/commit/61e4817406656985e9536abf6453f7b623b838f9) | `` automatic update `` |
| [`8a1ce36f`](https://github.com/nix-community/NUR/commit/8a1ce36f3d828901e25fa6c5de717c5b11aa82c1) | `` automatic update `` |
| [`5964d08c`](https://github.com/nix-community/NUR/commit/5964d08c6757ea20475441ac4bab676c5c19ae15) | `` automatic update `` |
| [`71377641`](https://github.com/nix-community/NUR/commit/71377641671e316bf2de5337b20eec027bc20a10) | `` automatic update `` |
| [`ac3a3e96`](https://github.com/nix-community/NUR/commit/ac3a3e96e38706fddc338a79b12e2be76c572045) | `` automatic update `` |