### PR TITLE
chore(flake/flake-parts): `7f38f25a` -> `af66ad14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754420989,
-        "narHash": "sha256-3e4wHzNwTMg7GaeLH9A091DMaO9AfFxUjpfqbddCUeo=",
+        "lastModified": 1754487366,
+        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7f38f25a44023a21a504bd3fd9d4f41c4a39f55c",
+        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                                                              |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`2936a61c`](https://github.com/hercules-ci/flake-parts/commit/2936a61cb6a2e98b93ad74b63334ec2c4fbb42cd) | `` Change docs for `flake.apps.<name>.<name>.*` to `flake.apps.<system>.<name>.*` `` |