### PR TITLE
chore(flake/nur): `a376e915` -> `0d75abff`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754512544,
-        "narHash": "sha256-cKCIJKp+zrXWBSZVE+Mz54zZ3Du2sdzM7xIbUECFamo=",
+        "lastModified": 1754537826,
+        "narHash": "sha256-5aNGYEe4nf4IkFw2JN2v3jpcqLhRwCY0rlVhGtOYcV4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a376e91594de596a6e525badc1dfa79181a1f4d4",
+        "rev": "0d75abff8343adaa20cd89b79e1f58d334101534",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`0d75abff`](https://github.com/nix-community/NUR/commit/0d75abff8343adaa20cd89b79e1f58d334101534) | `` automatic update `` |
| [`e17e7704`](https://github.com/nix-community/NUR/commit/e17e7704458de0ed07a36e2e029ebee6cd4fa081) | `` automatic update `` |
| [`3463ebe8`](https://github.com/nix-community/NUR/commit/3463ebe88afbcbb490332e9a4966f5add3279aeb) | `` automatic update `` |
| [`aa0b0703`](https://github.com/nix-community/NUR/commit/aa0b07033c3d738d673d21c2400bc5e3394a17fa) | `` automatic update `` |
| [`d257e6c2`](https://github.com/nix-community/NUR/commit/d257e6c27509be6edfae3e376bcf07123b05cf62) | `` automatic update `` |
| [`146053d7`](https://github.com/nix-community/NUR/commit/146053d72b83164afc79775f0e461607a732c621) | `` automatic update `` |