### PR TITLE
chore(flake/nur): `ad772d1e` -> `a2e5a13b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754541335,
-        "narHash": "sha256-eEG43FPg6E3Dxz/cUIk7iXFRYTSI/miRO26rS6YTqUc=",
+        "lastModified": 1754554088,
+        "narHash": "sha256-ACeIjiXNSzW06OyUPyYs5Mm5hcSmq2WGo697iJ25Izk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ad772d1e5ebea99e741f0e61a73655928bc53bfa",
+        "rev": "a2e5a13b547bb9cc88887949fe9a0958ad59f3da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a2e5a13b`](https://github.com/nix-community/NUR/commit/a2e5a13b547bb9cc88887949fe9a0958ad59f3da) | `` automatic update `` |
| [`bf5f19d6`](https://github.com/nix-community/NUR/commit/bf5f19d67bc2eb7ef0429734f8f9fdc84ca277f4) | `` automatic update `` |
| [`deaefede`](https://github.com/nix-community/NUR/commit/deaefedef12f15f59f503f38c36dec8956df9fbc) | `` automatic update `` |
| [`1f267a20`](https://github.com/nix-community/NUR/commit/1f267a20b62924a4e45878b1bf631a4a541a2a3b) | `` automatic update `` |
| [`13fdbbd9`](https://github.com/nix-community/NUR/commit/13fdbbd92ecc6ce8f3957aa1b32965d3b48bbd79) | `` automatic update `` |
| [`965610b6`](https://github.com/nix-community/NUR/commit/965610b676073fc87afe259b5c20f82cdeb07f8c) | `` automatic update `` |