### PR TITLE
chore(flake/nur): `a2e5a13b` -> `d26ed459`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754554088,
-        "narHash": "sha256-ACeIjiXNSzW06OyUPyYs5Mm5hcSmq2WGo697iJ25Izk=",
+        "lastModified": 1754573286,
+        "narHash": "sha256-pHAMQJG15rHf/WLw5vlLgMFXe/fLyNnpXU6rHkveAaA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2e5a13b547bb9cc88887949fe9a0958ad59f3da",
+        "rev": "d26ed459d1427517284c69002e78c89d8a923757",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d26ed459`](https://github.com/nix-community/NUR/commit/d26ed459d1427517284c69002e78c89d8a923757) | `` automatic update `` |
| [`e2b0a54f`](https://github.com/nix-community/NUR/commit/e2b0a54f3538a26b983ab3fe7fa2bdbf466621cd) | `` automatic update `` |
| [`af3bd79a`](https://github.com/nix-community/NUR/commit/af3bd79a8d016d6ddabae0bc754f8b3ee446fed2) | `` automatic update `` |
| [`c931e7ac`](https://github.com/nix-community/NUR/commit/c931e7accbf28f50bc147e2e88e7d5963cd9e777) | `` automatic update `` |