### PR TITLE
chore(flake/nur): `d26ed459` -> `bd7c4150`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1754214453,
-        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "lastModified": 1754498491,
+        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754573286,
-        "narHash": "sha256-pHAMQJG15rHf/WLw5vlLgMFXe/fLyNnpXU6rHkveAaA=",
+        "lastModified": 1754581054,
+        "narHash": "sha256-Qy/KBx5uQ7fkl90UXKT7vyHnBeIpNaEijuSj3gRAMLI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d26ed459d1427517284c69002e78c89d8a923757",
+        "rev": "bd7c41503777e7066cc261cbe8f5a52df3899034",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bd7c4150`](https://github.com/nix-community/NUR/commit/bd7c41503777e7066cc261cbe8f5a52df3899034) | `` automatic update `` |
| [`45c56bf8`](https://github.com/nix-community/NUR/commit/45c56bf867424cd5f48d859ecfce5bd9be7e06c2) | `` automatic update `` |
| [`4fe4c7df`](https://github.com/nix-community/NUR/commit/4fe4c7dfc7534f3b86a5986912eaff5961fba89f) | `` automatic update `` |
| [`7cfa649d`](https://github.com/nix-community/NUR/commit/7cfa649d67be382825da31d9918b879d2c467303) | `` automatic update `` |