### PR TITLE
chore(flake/nur): `bd7c4150` -> `f6bba0c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754581054,
-        "narHash": "sha256-Qy/KBx5uQ7fkl90UXKT7vyHnBeIpNaEijuSj3gRAMLI=",
+        "lastModified": 1754598997,
+        "narHash": "sha256-qqCfJGJ76D+QhcT51Um9NwEaB5GLXP8W6cDuwpycrOg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bd7c41503777e7066cc261cbe8f5a52df3899034",
+        "rev": "f6bba0c2f9b42b226160a703a6872aef98b3b5c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`f6bba0c2`](https://github.com/nix-community/NUR/commit/f6bba0c2f9b42b226160a703a6872aef98b3b5c2) | `` automatic update `` |
| [`e83c020e`](https://github.com/nix-community/NUR/commit/e83c020eb741f6911010e55965bbbf54817375b8) | `` automatic update `` |
| [`a1cd428f`](https://github.com/nix-community/NUR/commit/a1cd428f674559a9a025e4de920c869747c35e1d) | `` automatic update `` |
| [`6c9ed484`](https://github.com/nix-community/NUR/commit/6c9ed4848b1391acf83f01301e5cc705c7098279) | `` automatic update `` |
| [`24300e18`](https://github.com/nix-community/NUR/commit/24300e18c5dbd2c2f99e26060af5a1bfced524bd) | `` automatic update `` |
| [`ad14a39e`](https://github.com/nix-community/NUR/commit/ad14a39e62ab5399edea65d883480e94892003c7) | `` automatic update `` |