### PR TITLE
chore(flake/nur): `f6bba0c2` -> `72258557`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754598997,
-        "narHash": "sha256-qqCfJGJ76D+QhcT51Um9NwEaB5GLXP8W6cDuwpycrOg=",
+        "lastModified": 1754625650,
+        "narHash": "sha256-rluRc5fe5vBSP0+8zV6bE4mesfDLHM4pd5+oAnKU+j8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "f6bba0c2f9b42b226160a703a6872aef98b3b5c2",
+        "rev": "722585573a2088bb006f0ce690e34226a88b7eaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`72258557`](https://github.com/nix-community/NUR/commit/722585573a2088bb006f0ce690e34226a88b7eaf) | `` automatic update `` |
| [`5fdfaa7f`](https://github.com/nix-community/NUR/commit/5fdfaa7f0ac39424820bb9713d89fb5b8c2ba745) | `` automatic update `` |
| [`406f38d9`](https://github.com/nix-community/NUR/commit/406f38d9f39656a29834ae676b325fce94389ac8) | `` automatic update `` |
| [`83f0cbfd`](https://github.com/nix-community/NUR/commit/83f0cbfd218f15ddc240404ae3c2d59a81159aaa) | `` automatic update `` |
| [`6e608177`](https://github.com/nix-community/NUR/commit/6e608177a657d8e2ffb583c6e1b1ada201f9473d) | `` automatic update `` |
| [`39c383dd`](https://github.com/nix-community/NUR/commit/39c383dd6666960976171458b06f85e93f696221) | `` automatic update `` |
| [`f8740c69`](https://github.com/nix-community/NUR/commit/f8740c69be870349c463b3f75f65286cb5e48859) | `` automatic update `` |
| [`8dbde51a`](https://github.com/nix-community/NUR/commit/8dbde51a8508c2c6b620b6d4ef5b999393a4c442) | `` automatic update `` |
| [`c2cd35d8`](https://github.com/nix-community/NUR/commit/c2cd35d8a045b7e8e2fdbce9386e1f27becdee30) | `` automatic update `` |