### PR TITLE
chore(flake/nur): `72258557` -> `c207a5af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754625650,
-        "narHash": "sha256-rluRc5fe5vBSP0+8zV6bE4mesfDLHM4pd5+oAnKU+j8=",
+        "lastModified": 1754630052,
+        "narHash": "sha256-NCJ2F+xMLSPfD9TLZFO55NiNN2+Lee7tQBAcOcp/3Bo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "722585573a2088bb006f0ce690e34226a88b7eaf",
+        "rev": "c207a5afe9d4dc7b145a59f96f075f7155727779",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c207a5af`](https://github.com/nix-community/NUR/commit/c207a5afe9d4dc7b145a59f96f075f7155727779) | `` automatic update `` |
| [`689af376`](https://github.com/nix-community/NUR/commit/689af37663937bcfeaacf78fdc5bd9844da1443a) | `` automatic update `` |
| [`487e2c74`](https://github.com/nix-community/NUR/commit/487e2c74682a24fbdd40615d4bbf37b63ad55112) | `` automatic update `` |