### PR TITLE
chore(flake/nixpkgs): `ce01daeb` -> `e728d7ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754292888,
-        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
+        "lastModified": 1754563854,
+        "narHash": "sha256-YzNTExe3kMY9lYs23mZR7jsVHe5TWnpwNrsPOpFs/b8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
+        "rev": "e728d7ae4bb6394bbd19eec52b7358526a44c414",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| [`e728d7ae`](https://github.com/NixOS/nixpkgs/commit/e728d7ae4bb6394bbd19eec52b7358526a44c414) | `` nixos/ntpd-rs: hardening ``                                                                              |
| [`2070a9a5`](https://github.com/NixOS/nixpkgs/commit/2070a9a53cf50540017716b479efc7652be6cc75) | `` git-annex: apply workaround for test failure with git 2.50 ``                                            |
| [`89399783`](https://github.com/NixOS/nixpkgs/commit/89399783f57ecdebb495791acf326a3167056ff7) | `` darktable: fix build by using Saxon XSLT processor ``                                                    |
| [`3b07c0b2`](https://github.com/NixOS/nixpkgs/commit/3b07c0b2670d4a69126603f316d9bf32cf83f48c) | `` ungoogled-chromium: 138.0.7204.183-1 -> 139.0.7258.66-1 ``                                               |
| [`5ea5c21d`](https://github.com/NixOS/nixpkgs/commit/5ea5c21d18409fda4d307f2272255fbfbc577343) | `` veloren: fixup ``                                                                                        |
| [`b6f6f60b`](https://github.com/NixOS/nixpkgs/commit/b6f6f60b957e397b8cebc20c813e6b4bf4b7e404) | `` librewolf-unwrapped: 141.0-1 -> 141.0.2-1 ``                                                             |
| [`c0396c00`](https://github.com/NixOS/nixpkgs/commit/c0396c00111ac483d7e8e57fae9eb77ca4f8f7d4) | `` cudaPackages.cuda_cudart: move *.pc file to lib/pkgconfig ``                                             |
| [`d40ee9c7`](https://github.com/NixOS/nixpkgs/commit/d40ee9c760a26e8427b49d1d0e07401c94e31428) | `` nvidia-container-toolkit: add meta.mainProgram ``                                                        |
| [`721e6c73`](https://github.com/NixOS/nixpkgs/commit/721e6c731f9a4d85c4b7d3f23057d0be57c65056) | `` ci/eval/compare: don't treat renames as rebuilds ``                                                      |
| [`fe803fed`](https://github.com/NixOS/nixpkgs/commit/fe803fed242c97d1e6763f38d59bb76199404590) | `` workflows/eval: disable swap ``                                                                          |
| [`72a69300`](https://github.com/NixOS/nixpkgs/commit/72a693003fa362b4cb69b02c80c538562d229313) | `` flyctl: 0.3.161 -> 0.3.164 ``                                                                            |
| [`0eef8df7`](https://github.com/NixOS/nixpkgs/commit/0eef8df7d6024a1739b91548d35d7c6ea5714793) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.27.2 -> 0.28.0 ``                                       |
| [`182d20ac`](https://github.com/NixOS/nixpkgs/commit/182d20ac6454bef501bd986c4affaddfabf1294e) | `` lock: 1.6.6 -> 1.6.7 ``                                                                                  |
| [`558bcd4f`](https://github.com/NixOS/nixpkgs/commit/558bcd4fbd57df021010ef628a323dfbef733502) | `` komikku: 1.83.0 -> 1.84.0 ``                                                                             |
| [`3b095008`](https://github.com/NixOS/nixpkgs/commit/3b095008a5490125b140a6bdfd2a29185766054b) | `` garnet: 1.0.78 -> 1.0.79 ``                                                                              |
| [`655b0aaa`](https://github.com/NixOS/nixpkgs/commit/655b0aaa8759ed1ab56b0dc6e7b0797126e4f7c4) | `` containerd: 2.1.3 -> 2.1.4 ``                                                                            |
| [`9590f588`](https://github.com/NixOS/nixpkgs/commit/9590f588dee8205edcc40067f96b074ffe0b7cc5) | `` deja-dup: 48.2 -> 48.3 ``                                                                                |
| [`06b12192`](https://github.com/NixOS/nixpkgs/commit/06b12192038b0b66e6d7db091b332605ead33b79) | `` ledger-live-desktop: 2.120.1 -> 2.122.1 ``                                                               |
| [`ec15f99c`](https://github.com/NixOS/nixpkgs/commit/ec15f99cd4d4cc3033fe6e5f129cc297290c824a) | `` ledger-live-desktop: 2.118.1 -> 2.120.1 ``                                                               |
| [`d9c28e5b`](https://github.com/NixOS/nixpkgs/commit/d9c28e5b58e710f152794e1c9698890ebf80e2a7) | `` ledger-live-desktop: 2.117.0 -> 2.118.1 ``                                                               |
| [`b73a5706`](https://github.com/NixOS/nixpkgs/commit/b73a5706892acd1bce93fb6fded726a0d737699b) | `` ledger-live-desktop: 2.115.1 -> 2.117.0 ``                                                               |
| [`439ad697`](https://github.com/NixOS/nixpkgs/commit/439ad6979728cf56c5d5eab442537fffde808b09) | `` ledger-live-desktop: 2.113.2 -> 2.115.1 ``                                                               |
| [`8f1ce6b6`](https://github.com/NixOS/nixpkgs/commit/8f1ce6b610bc970de48339930ce2c1f64168af76) | `` ledger-live-desktop: 2.113.0 -> 2.113.2 ``                                                               |
| [`817311fb`](https://github.com/NixOS/nixpkgs/commit/817311fbfa07c3e08c7294a2c22d5b21c88a2230) | `` ledger-live-desktop: 2.111.0 -> 2.113.0 ``                                                               |
| [`08181f98`](https://github.com/NixOS/nixpkgs/commit/08181f98f1de13622a4c3de2648db74955d8a0ae) | `` cargo-tauri: unbreak test app ``                                                                         |
| [`c8264059`](https://github.com/NixOS/nixpkgs/commit/c82640597ddc7157f217caea1c077299c795d6b6) | `` cargo-tauri: 2.7.0 -> 2.7.1 ``                                                                           |
| [`2b6e4da1`](https://github.com/NixOS/nixpkgs/commit/2b6e4da18729b2331fde37e6e14d01c5dead2faf) | `` cargo-tauri: 2.6.2 -> 2.7.0 ``                                                                           |
| [`f62dea38`](https://github.com/NixOS/nixpkgs/commit/f62dea3802329c2bc98834107286521dd33cd396) | `` scotty: 0.7.0 -> 0.7.1 ``                                                                                |
| [`d0e1f053`](https://github.com/NixOS/nixpkgs/commit/d0e1f053ab469ed773b73eceb3f1685c78154e19) | `` asterisk: 20.15.0 -> 20.15.1 ``                                                                          |
| [`8dfda4eb`](https://github.com/NixOS/nixpkgs/commit/8dfda4eb6eb2353055d7640916e64804c4e87127) | `` lunatask: 2.1.2 -> 2.1.3 ``                                                                              |
| [`31b395d1`](https://github.com/NixOS/nixpkgs/commit/31b395d107b5cdc9847f9c2eb0ff000829190b6e) | `` mangojuice: 0.8.5 -> 0.8.6 ``                                                                            |
| [`2a49f218`](https://github.com/NixOS/nixpkgs/commit/2a49f2183e40db38aa40522f125420f0fafce809) | `` easyeffects: 7.2.4 -> 7.2.5 ``                                                                           |
| [`fccff6b6`](https://github.com/NixOS/nixpkgs/commit/fccff6b6e94752dc00f7a8bb1c3f06296d766cc4) | `` bign-handheld-thumbnailer: 1.1.2 -> 1.1.3 ``                                                             |
| [`28e6748d`](https://github.com/NixOS/nixpkgs/commit/28e6748d664460228b8e850814b7f07a373ce2f4) | `` upscaler: 1.5.2 -> 1.6.0 ``                                                                              |
| [`0dbfa596`](https://github.com/NixOS/nixpkgs/commit/0dbfa596193324ede7369e0ba86533d26a1fa56c) | `` lock: 1.6.5 -> 1.6.6 ``                                                                                  |
| [`6ecec3c4`](https://github.com/NixOS/nixpkgs/commit/6ecec3c4a1349d0e2cbb5e18fc68f02e96e64335) | `` firefox-bin-unwrapped: 141.0 -> 141.0.2 ``                                                               |
| [`d30a900d`](https://github.com/NixOS/nixpkgs/commit/d30a900d2ec50db45f56d928f971f421874fa173) | `` firefox-unwrapped: 141.0 -> 141.0.2 ``                                                                   |
| [`f500b9f3`](https://github.com/NixOS/nixpkgs/commit/f500b9f328b8e776274aa32ebe0063d3a914bc51) | `` buildMozillaMach: adjust macos sdk patch range ``                                                        |
| [`0ae3270e`](https://github.com/NixOS/nixpkgs/commit/0ae3270e59e3b221a2ccbd9579527c0666263804) | `` chromium,chromedriver: 138.0.7204.183 -> 139.0.7258.66 ``                                                |
| [`bd83070f`](https://github.com/NixOS/nixpkgs/commit/bd83070f34860b8d49b8f209f7d5208a5cee4281) | `` wordpress: 6.8.1 -> 6.8.2 ``                                                                             |
| [`370d6784`](https://github.com/NixOS/nixpkgs/commit/370d67848b3ddef59123d5423295d14c4d755451) | `` ci/treefmt: add markdown-code-runner ``                                                                  |
| [`004627e8`](https://github.com/NixOS/nixpkgs/commit/004627e8b44bf83f6085443b2e68f9fc629392f7) | `` nextcloudPackages.apps: update ``                                                                        |
| [`f35161a4`](https://github.com/NixOS/nixpkgs/commit/f35161a4dd4d1f35e5b123ea8a01ce9605bc39de) | `` k3s_1_30: 1.30.14+k3s1 -> 1.30.14+k3s2 ``                                                                |
| [`1da97cba`](https://github.com/NixOS/nixpkgs/commit/1da97cba67015c9e92c8868807335e544eab6c49) | `` k3s_1_31: 1.31.10+k3s1 -> 1.31.11+k3s1 ``                                                                |
| [`64a9da23`](https://github.com/NixOS/nixpkgs/commit/64a9da23fe425cc18cb8753ac0d746c416f93338) | `` k3s_1_32: 1.32.6+k3s1 -> 1.32.7+k3s1 ``                                                                  |
| [`0dc7fb80`](https://github.com/NixOS/nixpkgs/commit/0dc7fb80e64b340ea265cbdf72a059922fc4fb3a) | `` k3s_1_33: 1.33.2+k3s1 -> 1.33.3+k3s1 ``                                                                  |
| [`2ef4c0aa`](https://github.com/NixOS/nixpkgs/commit/2ef4c0aa1e33421f41268fd3f2240ec4d410eef6) | `` ci/tarball: build with Nix 2.30 ``                                                                       |
| [`dfd4c440`](https://github.com/NixOS/nixpkgs/commit/dfd4c4402da8fae30b8d4ee8750fefecafbb8c19) | `` ci/pinned: update ``                                                                                     |
| [`98b820ff`](https://github.com/NixOS/nixpkgs/commit/98b820ff85a38a1e6233fc05b61dc1901cfde819) | `` linuxKernel.packages.zenpower: fix build for 6.16 ``                                                     |
| [`7285a7c4`](https://github.com/NixOS/nixpkgs/commit/7285a7c47bfe1660ab0c4048fe8630431c2b49a3) | `` alt-tab-macos: 7.25.0 -> 7.26.0 ``                                                                       |
| [`3f8c22ec`](https://github.com/NixOS/nixpkgs/commit/3f8c22ec353ae6a3716953e87c1af79ef954893b) | `` matrix-synapse: 1.134.0 -> 1.135.0 ``                                                                    |
| [`96d6cb4e`](https://github.com/NixOS/nixpkgs/commit/96d6cb4e77984946ec72065af9c6a22e986666bd) | `` linux: fix structuredExtraConfig ``                                                                      |
| [`ea4e8de1`](https://github.com/NixOS/nixpkgs/commit/ea4e8de1fef6213e5c5f3c4b83eddd0829e1dca3) | `` sudo-rs: 0.2.7 -> 0.2.8 ``                                                                               |
| [`14636cb1`](https://github.com/NixOS/nixpkgs/commit/14636cb1163df50e6e366743eca092df18b1ebff) | `` cudaPackages.nsight_systems: fixup for SBSA aarch64-linux and x86_64-linux ``                            |
| [`ae8258de`](https://github.com/NixOS/nixpkgs/commit/ae8258de8aeac116e1db798d2099833ee5778953) | `` cudaPackages.nsight_compute: fixup for SBSA aarch64-linux ``                                             |
| [`6cad436b`](https://github.com/NixOS/nixpkgs/commit/6cad436bba337a4a773aef5d6a0f82476cd61f51) | `` cudaPackages.nsight_compute: fixup for Jetson aarch64-linux ``                                           |
| [`3605d2cb`](https://github.com/NixOS/nixpkgs/commit/3605d2cb0ae52698e891f071c3c248e117da5062) | `` top-level/cuda-packages.nix: note Jetson is unsupported by redist for CUDA 12.3 ``                       |
| [`e7db916a`](https://github.com/NixOS/nixpkgs/commit/e7db916a8ab7bb5fff49eb0824419bb17828ef94) | `` cudaPackages_11_0.autoAddCudaCompatRunpath.libcudaPath: fix the eval ``                                  |
| [`5e60eed2`](https://github.com/NixOS/nixpkgs/commit/5e60eed2853eb785db58550bf113d3fc2d0175a5) | `` cudaPackages.nsight_compute: fixup for x86_64-linux ``                                                   |
| [`09fe6f80`](https://github.com/NixOS/nixpkgs/commit/09fe6f80caf4dfa86bcfba6f44630342a459e699) | `` linux-manual: Handle scripts/kernel-doc.py ``                                                            |
| [`936bb69e`](https://github.com/NixOS/nixpkgs/commit/936bb69e21f7ace61d9d797c29b11f1f029e469e) | `` arc-browser: drop `donteatoreo` from maintainers ``                                                      |
| [`17943bb1`](https://github.com/NixOS/nixpkgs/commit/17943bb11c25f776e2801cdcf3a0df72ed35ade8) | `` zipline: set git sha ``                                                                                  |
| [`b21d3668`](https://github.com/NixOS/nixpkgs/commit/b21d366875a987f0753ab19f48385a566c1203ea) | `` zipline: 4.2.0 -> 4.2.1 ``                                                                               |
| [`4a76f173`](https://github.com/NixOS/nixpkgs/commit/4a76f1735ec3130ee495520c26a0aacae0b1dceb) | `` zipline: add meta.downloadPage ``                                                                        |
| [`091dc1fe`](https://github.com/NixOS/nixpkgs/commit/091dc1feb989828fdf54f52ddce705159ff59925) | `` discourse: 3.4.6 -> 3.4.7 ``                                                                             |
| [`be560eb4`](https://github.com/NixOS/nixpkgs/commit/be560eb4795f2940e5ee3b12668daeb5a9983e74) | `` postgresqlPackages.pgmq: 1.5.1 -> 1.6.1 ``                                                               |
| [`7664d249`](https://github.com/NixOS/nixpkgs/commit/7664d249e732b0ca02b5019f1e95a667c5098b6f) | `` vivaldi: 7.5.3735.56 -> 7.5.3735.58 ``                                                                   |
| [`e568c635`](https://github.com/NixOS/nixpkgs/commit/e568c635eb7b436a17db2e6b9db1819bcae29b9f) | `` discourse: 3.4.4 -> 3.4.6 ``                                                                             |
| [`b40ba952`](https://github.com/NixOS/nixpkgs/commit/b40ba952c20424eb438ee3d34d90eaadb3b7d4b1) | `` arc-browser: 1.101.0-64746 -> 1.106.0-66192 ``                                                           |
| [`41300da9`](https://github.com/NixOS/nixpkgs/commit/41300da938b69800de50beb23593490d4eb7b8d7) | `` arc-browser: use `xmlstartlet` for `passthru.updateScript` ``                                            |
| [`4a59193c`](https://github.com/NixOS/nixpkgs/commit/4a59193cedbd56e81ef5d938b8a1bb113b8711b3) | `` llvmPackages_git: 22.0.0-unstable-2025-07-28 -> 22.0.0-unstable-2025-08-03 ``                            |
| [`a83e8b4f`](https://github.com/NixOS/nixpkgs/commit/a83e8b4ff0d21e09aeeb6ca2de77d37df71c1fa1) | `` vencord: 1.12.7 -> 1.12.9 ``                                                                             |
| [`b30fcd33`](https://github.com/NixOS/nixpkgs/commit/b30fcd33772f59aa9700b4681530c563aa5ddf12) | `` raycast: 1.102.0 -> 1.102.3 ``                                                                           |
| [`5284c8af`](https://github.com/NixOS/nixpkgs/commit/5284c8afb606d129476ff10a707a444a778278cf) | `` raycast: 1.101.1 -> 1.102.0 ``                                                                           |
| [`c7b809e7`](https://github.com/NixOS/nixpkgs/commit/c7b809e7d222827c1b01f653447d1eaa12e462ab) | `` pff-tools: init at 0-unstable-2025-07-22 ``                                                              |
| [`b9e9c8d7`](https://github.com/NixOS/nixpkgs/commit/b9e9c8d7c2a38684a824f525496e949882ff91d3) | `` whois: 5.6.3 -> 5.6.4 ``                                                                                 |
| [`e3860924`](https://github.com/NixOS/nixpkgs/commit/e38609249c1ade9b981957f09c26087a9143e10d) | `` floorp: disable LTO ``                                                                                   |
| [`cbd55741`](https://github.com/NixOS/nixpkgs/commit/cbd5574177a3be618decebfd50b5d05ad75f5924) | `` signal-desktop: 7.62.0 -> 7.64.0 ``                                                                      |
| [`b688c0aa`](https://github.com/NixOS/nixpkgs/commit/b688c0aae68efb1153b15a414472126445749bee) | `` signal-desktop: remove useFetchCargoVendor usage ``                                                      |
| [`b3019620`](https://github.com/NixOS/nixpkgs/commit/b30196204896824b6b96a0bbad98ddf1d095055e) | `` sydbox: 3.36.0 -> 3.37.2 ``                                                                              |
| [`075e70ab`](https://github.com/NixOS/nixpkgs/commit/075e70ab32ea1d2df023a274c72b4a2fd39d54d2) | `` sydbox: conform descriptions to the standards ``                                                         |
| [`49ff3b79`](https://github.com/NixOS/nixpkgs/commit/49ff3b799b3fdf883ce123837dfc3c4fac39712c) | `` sydbox: remove useFetchCargoVendor usage ``                                                              |
| [`7806220a`](https://github.com/NixOS/nixpkgs/commit/7806220a46390cdc2850db2385620f24f389a07f) | `` ansible-lint: 25.6.1 -> 25.7.0 ``                                                                        |
| [`ddc8fb8b`](https://github.com/NixOS/nixpkgs/commit/ddc8fb8bf3b9d3e97a74dac2c676c22e623f1b5a) | `` ansible-lint: add maintainer robsliwi ``                                                                 |
| [`2d028444`](https://github.com/NixOS/nixpkgs/commit/2d0284440b6dbe5cb9bb517450bfea88592066e5) | `` maintainer: add robsliwi ``                                                                              |
| [`dd7bbf87`](https://github.com/NixOS/nixpkgs/commit/dd7bbf876c7a9ea810e58d9c7d5590e0f7d490a9) | `` ansible-lint: add maintainer HarisDotParis ``                                                            |
| [`20f9eb40`](https://github.com/NixOS/nixpkgs/commit/20f9eb409360566defe10ad684097c49f34be0e0) | `` maintainers: add HarisDotParis ``                                                                        |
| [`6e5f2b2f`](https://github.com/NixOS/nixpkgs/commit/6e5f2b2f9d0d137b6ca2389bd8784523872ac5d9) | `` ansible-lint: 25.5.0 -> 25.6.1 ``                                                                        |
| [`3346b2f6`](https://github.com/NixOS/nixpkgs/commit/3346b2f65401d5e395d60ee04c496b66989b30ab) | `` ansible-lint: 25.4.0 -> 25.5.0 ``                                                                        |
| [`ba04c8a4`](https://github.com/NixOS/nixpkgs/commit/ba04c8a47bb9bb0c59b991263886c36bf5aabd91) | `` qq: 3.2.18-2025-07-10 -> 3.2.18-2025-07-24 ``                                                            |
| [`a8a29589`](https://github.com/NixOS/nixpkgs/commit/a8a295894a81e11ce599e4414666a97f02b40547) | `` qq: 6.9.75-2025.6.26 -> 6.9.75-2025-07-10 (darwin); qq: 3.2.18-2025.6.26 -> 3.2.18-2025-07-10 (linux) `` |
| [`9118030b`](https://github.com/NixOS/nixpkgs/commit/9118030b79cba7a9e7e89c7776cc6ff5c90412f3) | `` linuxPackages.xone: 0.3.4 -> 0.3.5 ``                                                                    |
| [`603cc066`](https://github.com/NixOS/nixpkgs/commit/603cc066651de527fe0de2877f09cb338cff77d7) | `` linuxPackages.xone: 0.3.2 -> 0.3.4 ``                                                                    |
| [`bcd0355d`](https://github.com/NixOS/nixpkgs/commit/bcd0355da7718c444ce46641e6363d2544c8908b) | `` linuxPackages.xone: 0.3.1 -> 0.3.2 ``                                                                    |
| [`d3439c94`](https://github.com/NixOS/nixpkgs/commit/d3439c94d687cf391cd3e4559036f625a8e9c81a) | `` libreoffice: refresh patch, skip another test ``                                                         |
| [`326966f9`](https://github.com/NixOS/nixpkgs/commit/326966f9f440e1be74e982884aa559b0032967f7) | `` electron-chromedriver_37: 37.2.2 -> 37.2.4 ``                                                            |
| [`fc3388c2`](https://github.com/NixOS/nixpkgs/commit/fc3388c2cb7570f7a50401a771d44b2582901158) | `` electron_37-bin: 37.2.2 -> 37.2.4 ``                                                                     |
| [`7d99a4a0`](https://github.com/NixOS/nixpkgs/commit/7d99a4a0ebb9fa49625e910da204d0fe61008ad6) | `` electron-chromedriver_36: 36.7.1 -> 36.7.3 ``                                                            |
| [`6d1f4804`](https://github.com/NixOS/nixpkgs/commit/6d1f4804bfeb05ee0f997b83012a9e6dde94c0c3) | `` electron_36-bin: 36.7.1 -> 36.7.3 ``                                                                     |
| [`f30947d9`](https://github.com/NixOS/nixpkgs/commit/f30947d9a193903d0b166292fc1a1811ad3704f5) | `` electron-source.electron_37: 37.2.2 -> 37.2.4 ``                                                         |
| [`6c5d9858`](https://github.com/NixOS/nixpkgs/commit/6c5d98585f929b4f978b23c333af7035deecc532) | `` electron-source.electron_36: 36.7.1 -> 36.7.3 ``                                                         |
| [`3de8ddc5`](https://github.com/NixOS/nixpkgs/commit/3de8ddc5584db0fb44b3ea89490108b3caa5433e) | `` gcc: Switch a patch to the upstream source ``                                                            |
| [`46a43cb7`](https://github.com/NixOS/nixpkgs/commit/46a43cb74c964fa125e2aef04eb9ed838b3a2921) | `` gcc: Add missing patch comments ``                                                                       |
| [`a74839cb`](https://github.com/NixOS/nixpkgs/commit/a74839cb138cd6e2308278cab4191f63c4a921e4) | `` gcc14: fix build on aarch64-darwin ``                                                                    |
| [`ea66f28d`](https://github.com/NixOS/nixpkgs/commit/ea66f28dbcc57c32431412eef611d7ff5b576ecf) | `` linuxPackages.nvidiaPackages.(legacy/dc)_353: update to 535.261.03 ``                                    |
| [`9a5af430`](https://github.com/NixOS/nixpkgs/commit/9a5af43011e27ab33b8984ed5ef07b0957082dc0) | `` valkey: 8.0.3 -> 8.0.4 ``                                                                                |
| [`9b2e6707`](https://github.com/NixOS/nixpkgs/commit/9b2e67077eb3dfd091e76b81081971a5c99f6b14) | `` sqlite3: apply patch for CVE-2025-6965 ``                                                                |
| [`1e249672`](https://github.com/NixOS/nixpkgs/commit/1e24967297f7a338af258f8d6f8f9a0f9e544b76) | `` gnutls: patch security issues from 3.8.10 ``                                                             |
| [`2ab749af`](https://github.com/NixOS/nixpkgs/commit/2ab749af9ec0b3085ea9aa7fa3496a38e8e25d0d) | `` zeromq: Fix cross-compilation ``                                                                         |
| [`e72e95cd`](https://github.com/NixOS/nixpkgs/commit/e72e95cd0eb9cb8f41204b5c535c903bd2fefca4) | `` libadwaita: 1.7.4 -> 1.7.5 ``                                                                            |
| [`da627fde`](https://github.com/NixOS/nixpkgs/commit/da627fded43188c56e508fdd382af4b3b07fd0a1) | `` libopenmpt: 0.7.14 -> 0.7.15 ``                                                                          |
| [`d7024bf5`](https://github.com/NixOS/nixpkgs/commit/d7024bf5034d474cfb5eaf446bbb1d42c266b674) | `` glibc: 2.40-66 -> 2.40-142, fix CVE-2025-8058 ``                                                         |
| [`f6f9d47c`](https://github.com/NixOS/nixpkgs/commit/f6f9d47c324a7f2e9f95ff58d5465f63776af218) | `` vim-full: fix build when built with GUI support ``                                                       |
| [`d83829ec`](https://github.com/NixOS/nixpkgs/commit/d83829ec0cedcd50a73d626556e0fd046fb458c6) | `` vim: 9.1.1475 -> 9.1.1566 ``                                                                             |
| [`faecf38e`](https://github.com/NixOS/nixpkgs/commit/faecf38e3ce4e7e447138e436c9e9bce28081047) | `` vim: 9.1.1401 -> 9.1.1475 ``                                                                             |
| [`8b78716a`](https://github.com/NixOS/nixpkgs/commit/8b78716ad60a24d66527b39992c4d551394be66d) | `` vim: 9.1.1336 -> 9.1.1401 ``                                                                             |
| [`b8445e0c`](https://github.com/NixOS/nixpkgs/commit/b8445e0c757f50fd2ee5aa5cae2fd22862b5de68) | `` vim: 9.1.1336 -> 9.1.1385 ``                                                                             |
| [`a2df8d92`](https://github.com/NixOS/nixpkgs/commit/a2df8d9237684708ca5bf4741e4a8bdd216bef25) | `` pipewire: 1.4.6 -> 1.4.7 ``                                                                              |
| [`8a09eac6`](https://github.com/NixOS/nixpkgs/commit/8a09eac651fcee474f782143ff9947da6879b98a) | `` systemd: Use smaller bootctl patch. ``                                                                   |
| [`7aec6942`](https://github.com/NixOS/nixpkgs/commit/7aec69425808aa85ae4350f5b95094e50acd6884) | `` systemd: 257.6 -> 257.7 ``                                                                               |
| [`69cca83b`](https://github.com/NixOS/nixpkgs/commit/69cca83be8df21719e806a75cc91e582edadb7c2) | `` replace-workspace-values.py: Update cargo.toml on only lints replace ``                                  |
| [`8e304bd7`](https://github.com/NixOS/nixpkgs/commit/8e304bd757d85a883a0b0cc0c8ea6465743fd086) | `` djvulibre: 3.5.28 -> 3.5.29 ``                                                                           |
| [`636cdc21`](https://github.com/NixOS/nixpkgs/commit/636cdc21376b8d295a9ae67eb162cd8aa5b80e59) | `` util-linux: 2.41 -> 2.41.1 ``                                                                            |
| [`99093443`](https://github.com/NixOS/nixpkgs/commit/990934438f772f262ab4aa12d44af428823a6514) | `` util-linux: restrict X-mount.subdir to real mounts ``                                                    |
| [`21e9d944`](https://github.com/NixOS/nixpkgs/commit/21e9d9446e575aa878338d3f9150bb63318d2b9e) | `` nodejs_22: 22.17.0 -> 22.17.1 ``                                                                         |
| [`77c2a175`](https://github.com/NixOS/nixpkgs/commit/77c2a17594f6b683b2228d258b3f5ddef842558e) | `` unbound-full: 1.23.0 -> 1.23.1 ``                                                                        |
| [`5c7f8213`](https://github.com/NixOS/nixpkgs/commit/5c7f82132fc7c5c2ea902340533c0e4f84bad9e1) | `` perlPackages.AuthenSASL: apply patch for CVE-2025-40918 ``                                               |
| [`47bb459c`](https://github.com/NixOS/nixpkgs/commit/47bb459c41f79ca4907fdc7470328f7abff6b442) | `` libxml2: add patch for CVE-2025-6170 ``                                                                  |
| [`d0082400`](https://github.com/NixOS/nixpkgs/commit/d0082400bed98daf1a1e9aea6cf1243680271c65) | `` libxml2: add patch for CVE-2025-49795 ``                                                                 |
| [`acbf60a2`](https://github.com/NixOS/nixpkgs/commit/acbf60a2bcac9bda1c3d04dedf100f455972a2d7) | `` libxml2: add patch for CVE-2025-49794 and CVE-2025-49796 ``                                              |
| [`4294643b`](https://github.com/NixOS/nixpkgs/commit/4294643b75fcddcf31727f1b69ac8364bd47fad5) | `` libxml2: add patch for CVE-2025-6021 ``                                                                  |
| [`0cd89b9c`](https://github.com/NixOS/nixpkgs/commit/0cd89b9cb15747553e09fb1b73258588dfbd26c1) | `` scotty: 0.6.0 -> 0.7.0 ``                                                                                |