### PR TITLE
chore(flake/nur): `c207a5af` -> `899c01a6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754630052,
-        "narHash": "sha256-NCJ2F+xMLSPfD9TLZFO55NiNN2+Lee7tQBAcOcp/3Bo=",
+        "lastModified": 1754638791,
+        "narHash": "sha256-jsYuQTNtTwyaD6n2A8Vo53lqWypLcxXXqH2t+hf7Hts=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c207a5afe9d4dc7b145a59f96f075f7155727779",
+        "rev": "899c01a64333a9f97c3a2155fe3c812be99d308f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`899c01a6`](https://github.com/nix-community/NUR/commit/899c01a64333a9f97c3a2155fe3c812be99d308f) | `` automatic update `` |
| [`f15df3b0`](https://github.com/nix-community/NUR/commit/f15df3b0414f53fb17bd7b2418677edff21dae52) | `` automatic update `` |
| [`17f2a25d`](https://github.com/nix-community/NUR/commit/17f2a25d8e8a57863997b9befb8d1a46fce22e5e) | `` automatic update `` |
| [`7d56bd3d`](https://github.com/nix-community/NUR/commit/7d56bd3d88c61bd50b9643fa6b8c24e5e0bdc080) | `` automatic update `` |
| [`cfda0838`](https://github.com/nix-community/NUR/commit/cfda0838f4287fb523fe4457b4cc7a053ec12aad) | `` automatic update `` |