### PR TITLE
chore(flake/chaotic): `adaeec62` -> `849777a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1754597469,
-        "narHash": "sha256-XdVdXIU23qFcE1fdMVaaGhFSdVRGHjBXcRh/KHO9jqQ=",
+        "lastModified": 1754671632,
+        "narHash": "sha256-gJ3+wonqAfaiIDsZapIVQNSEJGviX1vsBCPa+IxzqGI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "adaeec6210ede1cdc71c5d65c89c8161490a9e64",
+        "rev": "849777a7d4e357460d885c25c8be7f8cb0366dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                    |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`849777a7`](https://github.com/chaotic-cx/nyx/commit/849777a7d4e357460d885c25c8be7f8cb0366dbb) | `` linux_cachyos: add BTRFS fix (#1142) `` |
| [`eac65038`](https://github.com/chaotic-cx/nyx/commit/eac6503825d79f5a86b22589fb3d1107b2eeec7c) | `` failures: update aarch64-darwin ``      |
| [`e8df4592`](https://github.com/chaotic-cx/nyx/commit/e8df4592de7f48db9816e27eef7b6533d2d3878a) | `` failures: update aarch64-linux ``       |