### PR TITLE
chore(flake/nur): `9ee0c53e` -> `a7f9761c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754668388,
-        "narHash": "sha256-oDjhvYVVaHwBh1SXmztGaX0Eq+ZmhjsyPk9zYfqoLTQ=",
+        "lastModified": 1754684884,
+        "narHash": "sha256-GH+UMIOJj7u/bW55dOOpD8HpVpc9WfU61iweM2nM68A=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9ee0c53e23da5d493ba601d8f700382d1ffdbb32",
+        "rev": "a7f9761c9dd71359cd9a6529078302a83e6deaac",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a7f9761c`](https://github.com/nix-community/NUR/commit/a7f9761c9dd71359cd9a6529078302a83e6deaac) | `` automatic update `` |
| [`77e5f5ba`](https://github.com/nix-community/NUR/commit/77e5f5ba0fe9184f2056e6bf447e47e89cfc5940) | `` automatic update `` |
| [`6a116ccb`](https://github.com/nix-community/NUR/commit/6a116ccbab3e9769eb7ae88320d35d071231318a) | `` automatic update `` |
| [`a9572eb5`](https://github.com/nix-community/NUR/commit/a9572eb5959d7ba356f61093c8b210cec9bd6498) | `` automatic update `` |
| [`7e8db4e3`](https://github.com/nix-community/NUR/commit/7e8db4e3c3e10259b6ebe54247566ab2336a8429) | `` automatic update `` |
| [`143d66fa`](https://github.com/nix-community/NUR/commit/143d66fa64ce39216522213180f312658c544e1b) | `` automatic update `` |