### PR TITLE
chore(flake/catppuccin): `9bdf7f5f` -> `10ebe711`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1754418797,
-        "narHash": "sha256-8UP/nu75GyNcdKW3FD/mRxhs5zWlRIpAQo8wgm9rVQE=",
+        "lastModified": 1754766349,
+        "narHash": "sha256-ykTnH2nnGnY2Z18sYWryLZFvxRxEcEfgZrl4FwoD4R8=",
         "owner": "catppuccin",
         "repo": "nix",
-        "rev": "9bdf7f5fb308409495523ea21bec5484b75b2492",
+        "rev": "10ebe71126157f98f180f747aec3fc4b497e3496",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`10ebe711`](https://github.com/catppuccin/nix/commit/10ebe71126157f98f180f747aec3fc4b497e3496) | `` fix(home-manager/sioyek): remove ifd (#686) `` |
| [`7b55c494`](https://github.com/catppuccin/nix/commit/7b55c4947c02f79dfd249432ccb0ada2726c29e2) | `` fix(home-manager/mako): remove ifd (#684) ``   |