### PR TITLE
chore(flake/nixpkgs): `e728d7ae` -> `fc756aa6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754563854,
-        "narHash": "sha256-YzNTExe3kMY9lYs23mZR7jsVHe5TWnpwNrsPOpFs/b8=",
+        "lastModified": 1754689972,
+        "narHash": "sha256-eogqv6FqZXHgqrbZzHnq43GalnRbLTkbBbFtEfm1RSc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e728d7ae4bb6394bbd19eec52b7358526a44c414",
+        "rev": "fc756aa6f5d3e2e5666efcf865d190701fef150a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`9625516f`](https://github.com/NixOS/nixpkgs/commit/9625516f64009e8cde19ccd336cc958f8b7074a0) | `` openbao: 2.3.1 -> 2.3.2 (#431937) ``                                         |
| [`e28c830e`](https://github.com/NixOS/nixpkgs/commit/e28c830e682da7b380c9900ea18fbc6c770959e9) | `` matrix-authentication-service: avoid updating to pre-releases ``             |
| [`a5516cd9`](https://github.com/NixOS/nixpkgs/commit/a5516cd91cef27ba5f530e8f4b5532592c290d97) | `` matrix-authentication-service: 0.19.0 -> 0.20.0 ``                           |
| [`acd96baa`](https://github.com/NixOS/nixpkgs/commit/acd96baaa98a3241f08b0995120d1cf190f9f0f6) | `` goresym: 3.0.2 -> 3.1.1 ``                                                   |
| [`c372e7eb`](https://github.com/NixOS/nixpkgs/commit/c372e7ebb3cbc3394513f5896e1bcf8ee2da783b) | `` zellij: 0.43.0 -> 0.43.1 ``                                                  |
| [`140ee724`](https://github.com/NixOS/nixpkgs/commit/140ee7240a8c5ce7a734732857075ec8eb9e5efa) | `` zellij: 0.42.2 -> 0.43.0 ``                                                  |
| [`732e4d32`](https://github.com/NixOS/nixpkgs/commit/732e4d32ad9fde9447d7cfca129b3afec7de00cc) | `` linux-firmware: 20250708 -> 20250808 ``                                      |
| [`bafac7a4`](https://github.com/NixOS/nixpkgs/commit/bafac7a4b24dd61afcea9243461232159fc5ef19) | `` postgresqlPackages.pg_squeeze: 1.7.0 -> 1.9.0 ``                             |
| [`2218a8f1`](https://github.com/NixOS/nixpkgs/commit/2218a8f19436606e0f0e02eb8d8e815664341e01) | `` psqlodbc: fix update script ``                                               |
| [`aa07b20e`](https://github.com/NixOS/nixpkgs/commit/aa07b20e4cec5a85efecc741ad9c001d5e1ee764) | `` psqlodbc: refactor ``                                                        |
| [`20033e4d`](https://github.com/NixOS/nixpkgs/commit/20033e4dba09ed0caab750f7312141f158a22e67) | `` postgresqlPackages.wal2json: fix update script and version ``                |
| [`1c9ca14a`](https://github.com/NixOS/nixpkgs/commit/1c9ca14a3ed644d070a5ed3f330c8686bca17b81) | `` postgresqlPackages.plr: fix update script and version ``                     |
| [`86421f74`](https://github.com/NixOS/nixpkgs/commit/86421f74db0ba0ac0ac1d168dd9dafe26bb331c4) | `` postgresqlPackages.pg_squeeze: fix update script and version ``              |
| [`50c1fc6b`](https://github.com/NixOS/nixpkgs/commit/50c1fc6b2ae79d06c044dcdb05a41896759a647d) | `` firefox-bin-unwrapped: 141.0.2 -> 141.0.3 (#431852) ``                       |
| [`750be938`](https://github.com/NixOS/nixpkgs/commit/750be938aa51f2d9d2c415e0b9af557d1bad981c) | `` firefox-unwrapped: 141.0.2 -> 141.0.3 ``                                     |
| [`49234445`](https://github.com/NixOS/nixpkgs/commit/49234445accbb847686d6c7dbf986968f1bd71fa) | `` limine: 9.5.0 -> 9.5.1 ``                                                    |
| [`17230108`](https://github.com/NixOS/nixpkgs/commit/17230108939c635ba73dbf766245ec32a70fbff2) | `` skim: 0.20.3 -> 0.20.4 ``                                                    |
| [`86a429b5`](https://github.com/NixOS/nixpkgs/commit/86a429b5699a687cf767de497ca6205c9b8622bb) | `` dosage-tracker: 1.9.9 -> 1.9.10 ``                                           |
| [`1338cf6b`](https://github.com/NixOS/nixpkgs/commit/1338cf6b7800c67552df465f5be15920a6664c59) | `` lock: 1.6.7 -> 1.7.0 ``                                                      |
| [`d44dc264`](https://github.com/NixOS/nixpkgs/commit/d44dc26458f360222211dd3f0b2bdb56c53050e5) | `` garnet: 1.0.79 -> 1.0.80 ``                                                  |
| [`66edfb70`](https://github.com/NixOS/nixpkgs/commit/66edfb702304d287cd73fdd1f29456ee92ec230a) | `` iotas: 0.11.0 -> 0.11.2 ``                                                   |
| [`b869e770`](https://github.com/NixOS/nixpkgs/commit/b869e770db56f8ccd1d058836256bdc59302dad5) | `` python313Packages.apprise: 1.9.3 -> 1.9.4 ``                                 |
| [`b92bf30d`](https://github.com/NixOS/nixpkgs/commit/b92bf30d07a2e8b2fbee5cf33f594d9e55713595) | `` moonlight: 1.3.25 -> 1.3.26 ``                                               |
| [`e1892e7e`](https://github.com/NixOS/nixpkgs/commit/e1892e7efbd44e4932a37a29002614d89c2d2994) | `` moonlight: 1.3.24 -> 1.3.25 ``                                               |
| [`3c619087`](https://github.com/NixOS/nixpkgs/commit/3c619087358d322391ffd0a7a6a427c140c7916e) | `` moonlight: 1.3.23 -> 1.3.24 ``                                               |
| [`9fb29b7b`](https://github.com/NixOS/nixpkgs/commit/9fb29b7b36affd58820391096bd1ab9260e0c841) | `` moonlight: 1.3.22 -> 1.3.23 ``                                               |
| [`c9d55134`](https://github.com/NixOS/nixpkgs/commit/c9d55134919b526aa08e9e3455054e9e62391e54) | `` thunderbird-esr-bin-unwrapped: 140.1.0esr -> 140.1.1esr ``                   |
| [`6ca72116`](https://github.com/NixOS/nixpkgs/commit/6ca72116114b0260b7352ac129e5521360b4f25e) | `` skim: 0.20.2 -> 0.20.3 ``                                                    |
| [`146b8445`](https://github.com/NixOS/nixpkgs/commit/146b84453b79d9e63a84a9bbed31eba71e614281) | `` skim: remove useFetchCargoVendor usage ``                                    |
| [`980e8e08`](https://github.com/NixOS/nixpkgs/commit/980e8e08c80595d2a2e8e7b3db8897f57d617062) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.28.0 -> 0.29.2 ``           |
| [`1f707051`](https://github.com/NixOS/nixpkgs/commit/1f70705173ff2cbf5178bddc8715234edf3233fd) | `` chhoto-url: 6.2.11 -> 6.2.12 ``                                              |
| [`cbb82660`](https://github.com/NixOS/nixpkgs/commit/cbb826608f7d081948eeb4ea0211b0cbd867b9d1) | `` go_1_23: 1.23.11 -> 1.23.12 ``                                               |
| [`039d9978`](https://github.com/NixOS/nixpkgs/commit/039d9978ddb881ae38f6f8efb0522e6c84402593) | `` {palemoon-bin,palemoon-gtk2-bin}: 33.8.1.1 -> 33.8.1.2 ``                    |
| [`6cdd6c90`](https://github.com/NixOS/nixpkgs/commit/6cdd6c90ff2e038d263a1338265f9d948b353ca9) | `` palemoon-gtk2-bin: init at 33.8.1.1 ``                                       |
| [`c1c78e22`](https://github.com/NixOS/nixpkgs/commit/c1c78e221875d67750d81cf516f68b0f5ff838db) | `` palemoon-bin: 33.8.0 -> 33.8.1.1 ``                                          |
| [`6dacbe78`](https://github.com/NixOS/nixpkgs/commit/6dacbe78803756d94d54844443ea3ec34175a72a) | `` nixos/tuned: enable upower with tuned-ppd ``                                 |
| [`550d8044`](https://github.com/NixOS/nixpkgs/commit/550d8044cab5439ff9b73fd0474dbe8ed8a94d0d) | `` mastodon: 4.3.10 -> 4.3.11 ``                                                |
| [`9a428fa7`](https://github.com/NixOS/nixpkgs/commit/9a428fa758a31423007c3ea2edf2d7252741d980) | `` hydra: 0-unstable-2025-07-17 -> 0-unstable-2025-08-05 ``                     |
| [`0de18272`](https://github.com/NixOS/nixpkgs/commit/0de18272769a3d81c92ecc8e2fd757f3db6e28b8) | `` lunatask: 2.1.3 -> 2.1.5 ``                                                  |
| [`b8ba4745`](https://github.com/NixOS/nixpkgs/commit/b8ba4745db63aeb993a92cfe9f8071a7b4471fe4) | `` paretosecurity: 0.2.38 -> 0.3.2 ``                                           |
| [`46cfbb22`](https://github.com/NixOS/nixpkgs/commit/46cfbb2297f574d5d0d1bc64df98ed4d1cf9e164) | `` hydra: 0-unstable-2025-06-15 -> 0-unstable-2025-07-17 ``                     |
| [`a1af4674`](https://github.com/NixOS/nixpkgs/commit/a1af4674aabb2b0c6ed6324297ff6831edc27a13) | `` hydra: disable nixpkgs-update ``                                             |
| [`4430bec5`](https://github.com/NixOS/nixpkgs/commit/4430bec5ea49bd66e78d23703284ddad39db203e) | `` hydra: 0-unstable-2025-05-27 -> 0-unstable-2025-06-15 ``                     |
| [`512b42e9`](https://github.com/NixOS/nixpkgs/commit/512b42e95b6a3cd419871c886f6eef286d223d0f) | `` hydra: avoid drawing in development dependencies from nix 2.29 on runtime `` |
| [`8867ddb4`](https://github.com/NixOS/nixpkgs/commit/8867ddb4bd7f4ba653c43d77c2765bead03567b4) | `` hydra: 0-unstable-2025-04-23 -> 0-unstable-2025-05-27 ``                     |
| [`06c376ed`](https://github.com/NixOS/nixpkgs/commit/06c376ed37831cc8346d01cca86e25492df71956) | `` hydra: 0-unstable-2025-04-16 -> 0-unstable-2025-04-23 ``                     |
| [`93132b34`](https://github.com/NixOS/nixpkgs/commit/93132b34ea70f649b00d3c11cb49f11f5f0bbe42) | `` open-policy-agent: disable flaky test ``                                     |
| [`2514f13a`](https://github.com/NixOS/nixpkgs/commit/2514f13aa63adaefe60174d0050a2c5282c582a5) | `` nixos/tuned: init ``                                                         |
| [`e5402ffd`](https://github.com/NixOS/nixpkgs/commit/e5402ffdadab0758cfe80fcf48d8139546a52f59) | `` tuned: init at 2.25.1 ``                                                     |
| [`6d1a9eb0`](https://github.com/NixOS/nixpkgs/commit/6d1a9eb0470842f86e32e78d17aae50c954fa0ad) | `` open-policy-agent: skip test too dependent on go version ``                  |
| [`0596fe1a`](https://github.com/NixOS/nixpkgs/commit/0596fe1aa576fb893af5e18411e7e8828ff257b8) | `` open-policy-agent: 1.5.1 -> 1.6.0 ``                                         |
| [`b7ab5d85`](https://github.com/NixOS/nixpkgs/commit/b7ab5d85102d8e87f485c8bd528b096c87ad5920) | `` open-policy-agent: 1.4.2 -> 1.5.1 ``                                         |
| [`d54a363f`](https://github.com/NixOS/nixpkgs/commit/d54a363f9d1339da235e1518d53006eaf6a54096) | `` openrazer: 3.10.1 -> 3.10.3 ``                                               |