### PR TITLE
chore(flake/nur): `a7f9761c` -> `f657c382`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1754498491,
-        "narHash": "sha256-erbiH2agUTD0Z30xcVSFcDHzkRvkRXOQ3lb887bcVrs=",
+        "lastModified": 1754725699,
+        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c2ae88e026f9525daf89587f3cbee584b92b6134",
+        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754684884,
-        "narHash": "sha256-GH+UMIOJj7u/bW55dOOpD8HpVpc9WfU61iweM2nM68A=",
+        "lastModified": 1754883319,
+        "narHash": "sha256-DUddNJ5q6sxzQ8SZaWt2KgNIATwSviQnpoeoUWCGopY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a7f9761c9dd71359cd9a6529078302a83e6deaac",
+        "rev": "f657c3820a06481f3a037ffba0e69d01f2cedfb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                   |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`f657c382`](https://github.com/nix-community/NUR/commit/f657c3820a06481f3a037ffba0e69d01f2cedfb2) | `` automatic update ``                    |
| [`edc5f74d`](https://github.com/nix-community/NUR/commit/edc5f74d1ae09ae61dfa83f24a91670d0192d7af) | `` automatic update ``                    |
| [`befb50ef`](https://github.com/nix-community/NUR/commit/befb50efa1b9bd139ba332a0ddebd166f6f8bb10) | `` automatic update ``                    |
| [`db39211c`](https://github.com/nix-community/NUR/commit/db39211c5c11eb70fb6aa1ef7635d96103a681d7) | `` automatic update ``                    |
| [`cbe6acaf`](https://github.com/nix-community/NUR/commit/cbe6acaf9d4328c133507a8c4ec0029b554596a4) | `` add LucasFA/nur-packages repository `` |
| [`a32ca4ad`](https://github.com/nix-community/NUR/commit/a32ca4ad6d505ec706049fea838479e6c3b22d5c) | `` automatic update ``                    |
| [`58e27e7d`](https://github.com/nix-community/NUR/commit/58e27e7d3650598b5ccf0c9c1828e65b999678da) | `` automatic update ``                    |
| [`a89cd86e`](https://github.com/nix-community/NUR/commit/a89cd86e9fbde50758b9febf2ecd3cb237cb398b) | `` automatic update ``                    |
| [`7527c3e2`](https://github.com/nix-community/NUR/commit/7527c3e2c2e7dbb2c6003f6664f6d0207b964c30) | `` automatic update ``                    |
| [`9c6f4286`](https://github.com/nix-community/NUR/commit/9c6f428670762cad26ca74b3cc0f4f18c38ffa5c) | `` automatic update ``                    |
| [`a286e74a`](https://github.com/nix-community/NUR/commit/a286e74a15884d69db0f339edcec52ca9cc4a7aa) | `` automatic update ``                    |
| [`7caea3a0`](https://github.com/nix-community/NUR/commit/7caea3a004ebf4311a6aee5e760aa002e12f9d53) | `` automatic update ``                    |
| [`9bdc8a9b`](https://github.com/nix-community/NUR/commit/9bdc8a9b23a1e444109ff6a214e2dc139837f777) | `` automatic update ``                    |
| [`dc2e9ee0`](https://github.com/nix-community/NUR/commit/dc2e9ee0ca7834444303d46c0fa071319fdf34b4) | `` automatic update ``                    |
| [`f8b74fe8`](https://github.com/nix-community/NUR/commit/f8b74fe8a3e9090cd6ddcfe3e1ed645d8f0ca4b6) | `` automatic update ``                    |
| [`428f3150`](https://github.com/nix-community/NUR/commit/428f3150049ea479555ed3a5925a76671ceee519) | `` automatic update ``                    |
| [`577219c8`](https://github.com/nix-community/NUR/commit/577219c836de74f7939766bbf5cb214331adff3b) | `` automatic update ``                    |
| [`259f2d13`](https://github.com/nix-community/NUR/commit/259f2d13d745251fa6ccee322b6a2cb954360d19) | `` automatic update ``                    |
| [`2559394a`](https://github.com/nix-community/NUR/commit/2559394a006926626578c0a79cac0108e35792a9) | `` automatic update ``                    |
| [`a6083f3b`](https://github.com/nix-community/NUR/commit/a6083f3bfa03f6a51f31ea88bf2ff8df9631716d) | `` automatic update ``                    |
| [`b185dda4`](https://github.com/nix-community/NUR/commit/b185dda47d8a32c711c4f91d77108c8900fd49c2) | `` automatic update ``                    |
| [`08179897`](https://github.com/nix-community/NUR/commit/08179897d21692cb0342bb5a97c358487a2ba79a) | `` automatic update ``                    |
| [`b06926f4`](https://github.com/nix-community/NUR/commit/b06926f44e4a2796c69b67b2a6f1d978dcdde289) | `` automatic update ``                    |
| [`d7188f19`](https://github.com/nix-community/NUR/commit/d7188f1972bc2f276634c713c85a46cb1fbc4edf) | `` automatic update ``                    |
| [`d499323f`](https://github.com/nix-community/NUR/commit/d499323fc7cd65de26727829ba15c82a7ee687af) | `` automatic update ``                    |
| [`df8ba88d`](https://github.com/nix-community/NUR/commit/df8ba88d99ade8c7bdeb0821ea36f764adffafd4) | `` automatic update ``                    |
| [`49b376f0`](https://github.com/nix-community/NUR/commit/49b376f0dfde378efa30fa99536dd87792e4d91f) | `` automatic update ``                    |
| [`27dfc5e3`](https://github.com/nix-community/NUR/commit/27dfc5e3bedd281be925bc290351890571a720d2) | `` automatic update ``                    |
| [`9a67b7a3`](https://github.com/nix-community/NUR/commit/9a67b7a39f21aa43c4b2eab787bb3801a96a7e0a) | `` automatic update ``                    |
| [`73e88c3b`](https://github.com/nix-community/NUR/commit/73e88c3b16e870bdaca8118f9dfc334568c4e34f) | `` automatic update ``                    |
| [`088c4a55`](https://github.com/nix-community/NUR/commit/088c4a5518345fc6748992ae8afacc3e7e71ed68) | `` automatic update ``                    |
| [`9ec75608`](https://github.com/nix-community/NUR/commit/9ec75608a46173f0c73ac27f6072b33ea4dcab4e) | `` automatic update ``                    |
| [`0b460b0d`](https://github.com/nix-community/NUR/commit/0b460b0d7f89284144bfd6ff62e5a94737dbdb00) | `` automatic update ``                    |
| [`e4b3278b`](https://github.com/nix-community/NUR/commit/e4b3278b92413a4da9bde04d888d6691e6bf5430) | `` automatic update ``                    |
| [`f6fa362b`](https://github.com/nix-community/NUR/commit/f6fa362b700f64a9ac6e7d38b06db4f0c8101b4c) | `` automatic update ``                    |
| [`a1f44faf`](https://github.com/nix-community/NUR/commit/a1f44faf8f6220a6521cc423a39a9e79ef69cfac) | `` automatic update ``                    |
| [`065dbab5`](https://github.com/nix-community/NUR/commit/065dbab502a419020ea2fa66341b09414221d9f8) | `` automatic update ``                    |
| [`1e9cb161`](https://github.com/nix-community/NUR/commit/1e9cb161a27e529ecd04944e7343593bfd783677) | `` automatic update ``                    |
| [`c27c35e0`](https://github.com/nix-community/NUR/commit/c27c35e0f6952710c5efb29b2bdfba82b768c667) | `` automatic update ``                    |
| [`3adc8bbe`](https://github.com/nix-community/NUR/commit/3adc8bbe079a7b2750aaf0dc1b68d1b884708746) | `` automatic update ``                    |
| [`a6de49fe`](https://github.com/nix-community/NUR/commit/a6de49feac597501623da2f2e365d5d66f785257) | `` automatic update ``                    |
| [`bee139fd`](https://github.com/nix-community/NUR/commit/bee139fd18b2d40a7de2e5d59f445ffda76ff3d9) | `` automatic update ``                    |
| [`0518f5e3`](https://github.com/nix-community/NUR/commit/0518f5e3fa7e370ecaae689c7b06fd73a130bd14) | `` automatic update ``                    |
| [`ab1e2e53`](https://github.com/nix-community/NUR/commit/ab1e2e53a418b3907f87c24ce277975438f1bd78) | `` automatic update ``                    |
| [`43c3526d`](https://github.com/nix-community/NUR/commit/43c3526d1c7a458bfc109365f9eb3562eab91d64) | `` automatic update ``                    |
| [`589f3ae5`](https://github.com/nix-community/NUR/commit/589f3ae52940a84418481842dcf9d481d25e6112) | `` automatic update ``                    |
| [`a5c25d12`](https://github.com/nix-community/NUR/commit/a5c25d1262ac8a0099d9fe57f43e878ffc8a8712) | `` automatic update ``                    |
| [`f3f2b53f`](https://github.com/nix-community/NUR/commit/f3f2b53fa00ac5d7492be43c09edcd25508106de) | `` automatic update ``                    |
| [`1c365e60`](https://github.com/nix-community/NUR/commit/1c365e600afe6787c0861e4fd8609d598c5e416c) | `` automatic update ``                    |
| [`df73561c`](https://github.com/nix-community/NUR/commit/df73561c2296efd4d715abc23d96c8c2a23eb6f7) | `` automatic update ``                    |
| [`a1540090`](https://github.com/nix-community/NUR/commit/a1540090ed59dc4e97b9ff78f56feafc1c1516db) | `` automatic update ``                    |
| [`5df63ce9`](https://github.com/nix-community/NUR/commit/5df63ce98cc60ec5de75ffd36366e284995351cc) | `` automatic update ``                    |
| [`748ed04a`](https://github.com/nix-community/NUR/commit/748ed04acf19f7b0df83cc9a5df05c7f42a0f87d) | `` automatic update ``                    |
| [`1abd3827`](https://github.com/nix-community/NUR/commit/1abd38275364cbddb7573568d6d034989295e163) | `` automatic update ``                    |
| [`72feb959`](https://github.com/nix-community/NUR/commit/72feb9594806cfe8a68b171d9f47e818a5999b5c) | `` automatic update ``                    |