### PR TITLE
chore(flake/umu): `61ce5572` -> `d9d6243d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -620,11 +620,11 @@
       },
       "locked": {
         "dir": "packaging/nix",
-        "lastModified": 1754522985,
-        "narHash": "sha256-hJJsCMuWacxiCUXbK6uwf6Bl+WjYjLogkUutpaZTjUI=",
+        "lastModified": 1754884722,
+        "narHash": "sha256-uO6eeS/0pQcL4EBkhiZVdEiSrGFqnDdhI6T1L8F9GpU=",
         "owner": "Open-Wine-Components",
         "repo": "umu-launcher",
-        "rev": "61ce5572d092764a75621eeb9dd4f90d3c0fe601",
+        "rev": "d9d6243d29449aad1fca269de412e686f1a03929",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                             | Message                                                 |
| ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- |
| [`d9d6243d`](https://github.com/Open-Wine-Components/umu-launcher/commit/d9d6243d29449aad1fca269de412e686f1a03929) | `` chore: bump urllib3 to 2.5.0 (#528) ``               |
| [`43cf4c3b`](https://github.com/Open-Wine-Components/umu-launcher/commit/43cf4c3bfaf128fb22f29652493f01b8c32100eb) | `` build: fix FileNotFound in Debian 12 build (#529) `` |
| [`0b7280f4`](https://github.com/Open-Wine-Components/umu-launcher/commit/0b7280f4de1e1e61388ab11425950d140fb3fba9) | `` build: drop filelock dependency in rpm (#527) ``     |