### PR TITLE
chore(flake/nixpkgs): `fc756aa6` -> `c5f08b62`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754689972,
-        "narHash": "sha256-eogqv6FqZXHgqrbZzHnq43GalnRbLTkbBbFtEfm1RSc=",
+        "lastModified": 1754767907,
+        "narHash": "sha256-8OnUzRQZkqtUol9vuUuQC30hzpMreKptNyET2T9lB6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fc756aa6f5d3e2e5666efcf865d190701fef150a",
+        "rev": "c5f08b62ed75415439d48152c2a784e36909b1bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`a9a7aad1`](https://github.com/NixOS/nixpkgs/commit/a9a7aad1dfe012524346f1b4eca03d013e1d1c0f) | `` libucontext: 1.2 -> 1.3.2 ``                                                                |
| [`63301f98`](https://github.com/NixOS/nixpkgs/commit/63301f9889a929c462cbae018b4adec59c782572) | `` .github/workflows: set timeouts ``                                                          |
| [`e278610b`](https://github.com/NixOS/nixpkgs/commit/e278610b7cb47dc8a97e64da082e5b5e1f8b1071) | `` Revert "workflows/eval: disable swap" ``                                                    |
| [`9a1f61be`](https://github.com/NixOS/nixpkgs/commit/9a1f61be71d16816cd5212088b3edb2dea23d5aa) | `` ananicy-rules-cachyos: 0-unstable-2025-07-06 -> 0-unstable-2025-08-06 ``                    |
| [`f36aefce`](https://github.com/NixOS/nixpkgs/commit/f36aefcee2561af1049b5d159bb71b24b068ea38) | `` ananicy-rules-cachyos: 0-unstable-2025-03-19 -> 0-unstable-2025-07-06 ``                    |
| [`527a77b0`](https://github.com/NixOS/nixpkgs/commit/527a77b032ca9f0940f0e8ce7912ebe15594009e) | `` dotenv-cli: 9.0.0 -> 10.0.0 ``                                                              |
| [`25d1a82f`](https://github.com/NixOS/nixpkgs/commit/25d1a82f7e341ed386479b4ecb73381373eeb7c3) | `` dotenv-cli: 8.0.0 -> 9.0.0 ``                                                               |
| [`b43aaa1d`](https://github.com/NixOS/nixpkgs/commit/b43aaa1d487b1be893de568e1cec4101078cf4c2) | `` microsoft-edge: 138.0.3351.121 -> 139.0.3405.86 ``                                          |
| [`8c608414`](https://github.com/NixOS/nixpkgs/commit/8c6084146f81789043de945f286b30a9c9694716) | `` lixPackageSets.git: 2.94.0-pre-20250704_362bfd827f52 -> 2.94.0-pre-20250807_8bbd5e1d0df9 `` |
| [`7ddb7fe6`](https://github.com/NixOS/nixpkgs/commit/7ddb7fe62c290c554d6280178ba86ebe811987fc) | `` lixPackageSets.*.lix: use buildPackages.python3 instead of python3.pythonOnBuildForHost ``  |
| [`70209079`](https://github.com/NixOS/nixpkgs/commit/702090798968c57f7f5679ba8cf37ce82329f73d) | `` lixPackageSets.*.lix: omit unneeded Python packages when !doInstallCheck ``                 |
| [`ffdd32dc`](https://github.com/NixOS/nixpkgs/commit/ffdd32dcfc95282ff372f306636525016c84994c) | `` lixPackageSets.*.lix: stop copying unnecessary boost libraries ``                           |
| [`b625e6da`](https://github.com/NixOS/nixpkgs/commit/b625e6da534865fd1c2c67e2029cdabe686596ad) | `` capnproto: fix platform offset ``                                                           |
| [`ac3fc443`](https://github.com/NixOS/nixpkgs/commit/ac3fc4431f31e332c3e66d04e6ee9134cccf25bc) | `` mount-zip: 1.8 -> 1.10 ``                                                                   |
| [`41fff04d`](https://github.com/NixOS/nixpkgs/commit/41fff04d29021e39b44731b8e2ea040deb6ffc5f) | `` ci/eval: use sane defaults ``                                                               |
| [`174299e3`](https://github.com/NixOS/nixpkgs/commit/174299e35da30ae606741efd09e0718aed20fc18) | `` ci/eval: reduce closure size ``                                                             |
| [`2247d44f`](https://github.com/NixOS/nixpkgs/commit/2247d44f7e59fbcc790f4ecc2459d3a767a57478) | `` ci/eval: return min memory in megabyte ``                                                   |
| [`037db9a0`](https://github.com/NixOS/nixpkgs/commit/037db9a08a032a1a63198278d4f7281fb2618abd) | `` ci/eval: fix min-free-swap report ``                                                        |
| [`b41a5c23`](https://github.com/NixOS/nixpkgs/commit/b41a5c23a34366eec84ac288b0b179e6ca838616) | `` firefox-devedition-unwrapped: 142.0b3 -> 142.0b8 ``                                         |
| [`06263803`](https://github.com/NixOS/nixpkgs/commit/06263803737c31f4afee37442e923aa857fad04d) | `` firefox-beta-unwrapped: 142.0b3 -> 142.0b8 ``                                               |
| [`777cdc5a`](https://github.com/NixOS/nixpkgs/commit/777cdc5a8b394f640f12992209ab3655eefa7cad) | `` buildRustPackage: warn on explicit useFetchCargoVendor ``                                   |
| [`6b83af49`](https://github.com/NixOS/nixpkgs/commit/6b83af496a6fbcbfd87b05b8687d6c108867a0c0) | `` postfix-tlspol: 1.8.12 -> 1.8.13 ``                                                         |
| [`93852307`](https://github.com/NixOS/nixpkgs/commit/93852307e090b51a44a5c377f4129e2b2a19311c) | `` treewide: remove useFetchCargoVendor usages ``                                              |
| [`074de1f5`](https://github.com/NixOS/nixpkgs/commit/074de1f5a60d40332ad31ab29b7ddb08a09b643d) | `` linuxKernel.kernels.linux_lqx: 6.15.8 -> 6.15.9 ``                                          |
| [`c6766ac6`](https://github.com/NixOS/nixpkgs/commit/c6766ac6e91946b10a0e0aec45e247a7d7cf9e66) | `` onlyoffice-desktopeditors: 8.3.1 -> 9.0.0 (#419953) ``                                      |
| [`4cb97983`](https://github.com/NixOS/nixpkgs/commit/4cb97983e8170d511041b20e07ac7964431bf0ac) | `` onlyoffice-documentserver: 8.3.2 -> 8.3.3 ``                                                |
| [`7bf3e9c9`](https://github.com/NixOS/nixpkgs/commit/7bf3e9c90b2a5a07335be17c700dc40888ffcc1c) | `` exercise-timer: 1.8.4 -> 1.8.5 ``                                                           |
| [`57742b20`](https://github.com/NixOS/nixpkgs/commit/57742b2091c1762064576a258b053c2c8c2ee57b) | `` pixelorama: 1.1.1 -> 1.1.3 ``                                                               |
| [`2e783f8a`](https://github.com/NixOS/nixpkgs/commit/2e783f8a5488fc59f47a10b106257f92b25f4545) | `` brave: 1.80.125 -> 1.81.131 ``                                                              |
| [`06ece53b`](https://github.com/NixOS/nixpkgs/commit/06ece53bbdb65930ed1bb89f0a2cfc002345ac59) | `` symbola: fix disappearing source (#425659) ``                                               |
| [`f49d03ac`](https://github.com/NixOS/nixpkgs/commit/f49d03ac7b772c2634e8ddbce186a8e9c1d1100c) | `` mysql84: 8.4.5 -> 8.4.6 ``                                                                  |
| [`a4ffee2f`](https://github.com/NixOS/nixpkgs/commit/a4ffee2fbc0166945269bf8dc89b51bcd6256ab4) | `` mysql80: 8.0.42 -> 8.0.43 ``                                                                |
| [`18872c61`](https://github.com/NixOS/nixpkgs/commit/18872c61b368739995bba0929738906406cc1f87) | `` recordbox: 0.9.3 -> 0.10.3 ``                                                               |
| [`c8b74901`](https://github.com/NixOS/nixpkgs/commit/c8b7490123500600394b72cdff1b69df0f660d94) | `` corosync: apply patch for CVE-2025-30472 ``                                                 |
| [`71764e30`](https://github.com/NixOS/nixpkgs/commit/71764e30005c5c39c2572cc4302a0071784d1e44) | `` tuba: 0.9.2 -> 0.10.0 ``                                                                    |
| [`37930cbd`](https://github.com/NixOS/nixpkgs/commit/37930cbdc33c7f4138648d2b6f2736542ff74a47) | `` limine: 9.5.1 -> 9.5.4 ``                                                                   |
| [`9400ef32`](https://github.com/NixOS/nixpkgs/commit/9400ef329f8231301209b663bc8b95a479a7fbd6) | `` signal-desktop-bin: 7.59.0 -> 7.64.0 (#422163) ``                                           |
| [`d0f4243c`](https://github.com/NixOS/nixpkgs/commit/d0f4243c265a50320759333e70d0c3fb4b4fc71d) | `` electron-source.electron_37: 37.2.5 -> 37.2.6 ``                                            |
| [`8b899227`](https://github.com/NixOS/nixpkgs/commit/8b899227c319c611863902c6d84b2bb29d34cab2) | `` electron-source.electron_35: 35.7.2 -> 35.7.4 ``                                            |
| [`3d5a3aff`](https://github.com/NixOS/nixpkgs/commit/3d5a3affabfa85e47089994952698e78002c7514) | `` electron-chromedriver_37: 37.2.5 -> 37.2.6 ``                                               |
| [`d04c8987`](https://github.com/NixOS/nixpkgs/commit/d04c89877e3c432dbbe93ccebf5103aab4b2bac4) | `` electron_37-bin: 37.2.5 -> 37.2.6 ``                                                        |
| [`470fe587`](https://github.com/NixOS/nixpkgs/commit/470fe587cb1d9585322a09fc8522682f6e35051a) | `` electron-chromedriver_35: 35.7.2 -> 35.7.4 ``                                               |
| [`828502f7`](https://github.com/NixOS/nixpkgs/commit/828502f7e2cef25ab883cddc9bcf399097872a96) | `` electron_35-bin: 35.7.2 -> 35.7.4 ``                                                        |
| [`a953c730`](https://github.com/NixOS/nixpkgs/commit/a953c730c08f017f6fc64f50eef7e5bf54cf92b4) | `` electron-source.electron_37: 37.2.4 -> 37.2.5 ``                                            |
| [`b7ae0627`](https://github.com/NixOS/nixpkgs/commit/b7ae062760371ad95a277fdf0278ef466ffe36c6) | `` electron-chromedriver_37: 37.2.4 -> 37.2.5 ``                                               |
| [`f9f555c9`](https://github.com/NixOS/nixpkgs/commit/f9f555c950ff7edd9e96d9aa5e028fa5c04f56bd) | `` electron_37-bin: 37.2.4 -> 37.2.5 ``                                                        |
| [`a4cc0597`](https://github.com/NixOS/nixpkgs/commit/a4cc05972fc2c684962167e66fedc0452d4a0557) | `` docker_25: 25.0.11 -> 25.0.12 ``                                                            |
| [`02cc59c7`](https://github.com/NixOS/nixpkgs/commit/02cc59c7a93dca88d767e278d6e1456fcb8248c1) | `` docker_28: 28.3.2 -> 28.3.3 ``                                                              |
| [`7f19205f`](https://github.com/NixOS/nixpkgs/commit/7f19205f846f62c0d24d39f364c47eec81b44ac3) | `` btop: 1.4.3 -> 1.4.4 ``                                                                     |
| [`b2e9c375`](https://github.com/NixOS/nixpkgs/commit/b2e9c3752703f444ee0552b292db9950af0ab483) | `` wolfssl: 5.7.6 -> 5.8.2 ``                                                                  |
| [`281aac13`](https://github.com/NixOS/nixpkgs/commit/281aac132f6cd84252a5a242cde14c183f600cbc) | `` nodejs_24: 24.4.1 -> 24.5.0 ``                                                              |
| [`9b54c375`](https://github.com/NixOS/nixpkgs/commit/9b54c375fc5c6119dc5056fb33b7e04db77b202f) | `` exodus: 25.9.2 -> 25.28.4 ``                                                                |
| [`a7f31b68`](https://github.com/NixOS/nixpkgs/commit/a7f31b68ca972ce5ed972a5ccf7e733e59b9bf4f) | `` gnomeExtensions.argos: unstable-2024-10-28 → unstable-2025-03-27 ``                         |
| [`c4f1c2e8`](https://github.com/NixOS/nixpkgs/commit/c4f1c2e8cc345c70485a25c76bcc1d1ca6f6da03) | `` firefly-iii-data-importer: 1.7.8 -> 1.7.9 ``                                                |
| [`4b555c18`](https://github.com/NixOS/nixpkgs/commit/4b555c184bf6f0859fc62d2976e187dfb5da5ba8) | `` nixos/garage: set LimitNOFILE (#429633) ``                                                  |
| [`f61b38a6`](https://github.com/NixOS/nixpkgs/commit/f61b38a6d05e281c9328bbbabfbf425493969db6) | `` ibus-engines.table-others: 1.3.20 -> 1.3.21 ``                                              |
| [`3b5f0b9c`](https://github.com/NixOS/nixpkgs/commit/3b5f0b9ca6552aa8b52b7477014f6fdd99f060fd) | `` nixosTests.firefly-iii: Added meta.platforms so that tests are skipped appropriately ``     |
| [`301ddd7f`](https://github.com/NixOS/nixpkgs/commit/301ddd7f6ee5d43f81e198d1f589775bfb4ddcc8) | `` geph: 0.2.61 -> 0.2.72 ``                                                                   |
| [`7e8901b4`](https://github.com/NixOS/nixpkgs/commit/7e8901b453fac6098b5079cf28a7354c1159ae7a) | `` snipe-it: 8.1.18 -> 8.2.0 ``                                                                |
| [`9021c547`](https://github.com/NixOS/nixpkgs/commit/9021c5474f94f795b0777ae140180bc6eb379262) | `` ferdium: update version to 7.1.0 and fix hash values ``                                     |
| [`3f014330`](https://github.com/NixOS/nixpkgs/commit/3f014330108c593ddadb717c5f33193f886621e0) | `` tauno-monitor: 0.2.9 -> 0.2.11 ``                                                           |
| [`1357ee16`](https://github.com/NixOS/nixpkgs/commit/1357ee16cb2d578ad4eed1fe5104474fec2aa235) | `` nixos/iio: add package option ``                                                            |
| [`04f62c8c`](https://github.com/NixOS/nixpkgs/commit/04f62c8c0a65f78097c3ce632473bc86333e0a28) | `` peertube: remove spawn ``                                                                   |
| [`0b65aa02`](https://github.com/NixOS/nixpkgs/commit/0b65aa025ae08c83d12f2420f8ca825a0e24ed15) | `` mongodb-7_0: 7.0.16 -> 7.0.21 ``                                                            |
| [`0603a0a1`](https://github.com/NixOS/nixpkgs/commit/0603a0a1a29f93c0be3f97fb141a93418cb82c76) | `` bitwig-studio: 5.3.8 -> 5.3.11 ``                                                           |
| [`fb3005f6`](https://github.com/NixOS/nixpkgs/commit/fb3005f6a55fba424724e864ea714c63da7b054c) | `` pkgsStatic.difftastic: fix build ``                                                         |
| [`ac28d19b`](https://github.com/NixOS/nixpkgs/commit/ac28d19b35a19b1575b082815660bf5446fe8c95) | `` netexec: updating impacket rev ``                                                           |
| [`fc346e51`](https://github.com/NixOS/nixpkgs/commit/fc346e51a69492473d15a28e5104a8b5dd07c081) | `` andcli: 2.2.0 -> 2.3.0 ``                                                                   |
| [`d728f82e`](https://github.com/NixOS/nixpkgs/commit/d728f82eabfc2309d959cde674671f737bef23d1) | `` jdk11: 11.0.26+4 -> 11.0.27+6 ``                                                            |
| [`532ef10b`](https://github.com/NixOS/nixpkgs/commit/532ef10bf8ae219601a70e42220ca4a43fe6f391) | `` python3Packages.xonsh: 0.19.4 -> 0.19.9 ``                                                  |
| [`af6b9fe6`](https://github.com/NixOS/nixpkgs/commit/af6b9fe6868c2a45871784842426b12f1ab5e149) | `` ibus-table-chinese: 1.8.3 -> 1.8.12 ``                                                      |