### PR TITLE
chore(flake/nur): `9d09b338` -> `1d9e1938`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754886860,
-        "narHash": "sha256-NYK0ZnScBtmPGaI2xfRUBHq8GjicicFyrlX6+jPaCa0=",
+        "lastModified": 1754900567,
+        "narHash": "sha256-C4USMp2OHIblVdZNV4GjXbyOA4oZxPh30x6O+VG/Q7s=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "9d09b338ff7ca6739f59554161c9824356ad0ba2",
+        "rev": "1d9e19387612b1fe685386e34aec28992d8d4b88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1d9e1938`](https://github.com/nix-community/NUR/commit/1d9e19387612b1fe685386e34aec28992d8d4b88) | `` automatic update `` |
| [`3141b19c`](https://github.com/nix-community/NUR/commit/3141b19c94536d4024845ca8d30e2dd08dbaeb45) | `` automatic update `` |
| [`d7fa4271`](https://github.com/nix-community/NUR/commit/d7fa4271e67a1004ab00f811e043ff58aee2b1ce) | `` automatic update `` |
| [`cd71f0ec`](https://github.com/nix-community/NUR/commit/cd71f0ecdec74d6fdfeaaf1196901247bdd2ba5b) | `` automatic update `` |