### PR TITLE
chore(flake/nur): `1d9e1938` -> `dacefaca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754900567,
-        "narHash": "sha256-C4USMp2OHIblVdZNV4GjXbyOA4oZxPh30x6O+VG/Q7s=",
+        "lastModified": 1754919665,
+        "narHash": "sha256-LiABWkHPyjaLvI82zNB9R9SDnL008MqPdzEms4VDvsU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1d9e19387612b1fe685386e34aec28992d8d4b88",
+        "rev": "dacefaca6d7c2ae8fea96a103705c78bd5919133",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                  |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`dacefaca`](https://github.com/nix-community/NUR/commit/dacefaca6d7c2ae8fea96a103705c78bd5919133) | `` automatic update ``                   |
| [`5fbe3ee1`](https://github.com/nix-community/NUR/commit/5fbe3ee172c39acc867caca644f879faef7900a7) | `` add hexadecimalDinosaur repository `` |
| [`6ab440d1`](https://github.com/nix-community/NUR/commit/6ab440d1cb938616cf798984f8f48ec0b43939ad) | `` automatic update ``                   |
| [`aad77791`](https://github.com/nix-community/NUR/commit/aad77791922ff82a61a40daf047e41878e82ab2e) | `` automatic update ``                   |
| [`2667d0ce`](https://github.com/nix-community/NUR/commit/2667d0ce65470d926631400f82406d278be255e0) | `` automatic update ``                   |
| [`45735eca`](https://github.com/nix-community/NUR/commit/45735eca11abd2575aac2a252bb4935dc32b57d9) | `` automatic update ``                   |
| [`8b7bc4e2`](https://github.com/nix-community/NUR/commit/8b7bc4e294888ffe1ab16d554be7f6b205453915) | `` automatic update ``                   |
| [`aab204f3`](https://github.com/nix-community/NUR/commit/aab204f335aa2456797a3ef3fca6ccdbdc9a129b) | `` automatic update ``                   |