### PR TITLE
chore(flake/nur): `ebb2bbd6` -> `459a8cdd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754931080,
-        "narHash": "sha256-BFozHBLSeTVmOM4HWeFepNtllO9jIRHm3i6HAPjGOtw=",
+        "lastModified": 1754943006,
+        "narHash": "sha256-zAGY2vo2LMwz3JVArwkbImEXzUTtT0u0lLopoD7yiWI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ebb2bbd65bec6297aab1ddfa171e691a69406530",
+        "rev": "459a8cdd1c44b52e0e454015a1f44fb85c188bd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                           |
| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`459a8cdd`](https://github.com/nix-community/NUR/commit/459a8cdd1c44b52e0e454015a1f44fb85c188bd7) | `` automatic update ``                                            |
| [`ab485680`](https://github.com/nix-community/NUR/commit/ab485680208dfe0ac1cd928c97f2b2e4df5a5236) | `` add thk repository ``                                          |
| [`e9f07460`](https://github.com/nix-community/NUR/commit/e9f0746030e4740cc1ac0d52a896828129079107) | `` docs: nur.overlay has been replaced by nur.overlays.default `` |
| [`dda1653e`](https://github.com/nix-community/NUR/commit/dda1653ebac900f4fde762c5bc68ae0f014ad304) | `` automatic update ``                                            |
| [`09232cbf`](https://github.com/nix-community/NUR/commit/09232cbf5744686dcfcbc15493f709acb3150e36) | `` automatic update ``                                            |
| [`bdd763a5`](https://github.com/nix-community/NUR/commit/bdd763a5cefcde814548ce99516b71169ea10a5d) | `` automatic update ``                                            |
| [`ac764b34`](https://github.com/nix-community/NUR/commit/ac764b3412faeed1a37c7d21f30bc0fbe547f773) | `` automatic update ``                                            |