### PR TITLE
chore(flake/nur): `459a8cdd` -> `050f7dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754943006,
-        "narHash": "sha256-zAGY2vo2LMwz3JVArwkbImEXzUTtT0u0lLopoD7yiWI=",
+        "lastModified": 1754969204,
+        "narHash": "sha256-etUYRTJmfH+MKCupM5TredL4gU89CCFpVcLT9FnqO5U=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "459a8cdd1c44b52e0e454015a1f44fb85c188bd7",
+        "rev": "050f7dc24368864b02ad163afefcb33b3786b9be",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`050f7dc2`](https://github.com/nix-community/NUR/commit/050f7dc24368864b02ad163afefcb33b3786b9be) | `` automatic update `` |
| [`aea3d34a`](https://github.com/nix-community/NUR/commit/aea3d34a21199a9e5545cbb088a4750c5a80f38e) | `` automatic update `` |
| [`fdd4b882`](https://github.com/nix-community/NUR/commit/fdd4b882fb9f7bd9b6ac331cc2a78ce6912b4ec2) | `` automatic update `` |
| [`74903968`](https://github.com/nix-community/NUR/commit/74903968ac0202a4d3d71f9ee55ac3219cb77326) | `` automatic update `` |
| [`e5825a08`](https://github.com/nix-community/NUR/commit/e5825a088c4ab9b83b5875cd944ebdccfa81149b) | `` automatic update `` |
| [`f55ffbd1`](https://github.com/nix-community/NUR/commit/f55ffbd1fafeccb1a6bea996ce9a3c746c31a5fa) | `` automatic update `` |
| [`3bccbcfb`](https://github.com/nix-community/NUR/commit/3bccbcfb6827e976fd8a25c7a35e962311e5df49) | `` automatic update `` |
| [`c8eb4ac3`](https://github.com/nix-community/NUR/commit/c8eb4ac3ef8f4da2f3be3a15258ce252bdfcaee5) | `` automatic update `` |
| [`12edbcb1`](https://github.com/nix-community/NUR/commit/12edbcb1f2a857fff3892469ff1d3cbfc4f6f9a6) | `` automatic update `` |
| [`449660f1`](https://github.com/nix-community/NUR/commit/449660f1a9060f54576981ff3b36379e1cb2ee8c) | `` automatic update `` |