### PR TITLE
chore(flake/nur): `c5e1362e` -> `92d36e6b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754974375,
-        "narHash": "sha256-576emGtOpRSnCyvVzz3gLJDAoKO/5oWsngVS9ZiQNek=",
+        "lastModified": 1754987913,
+        "narHash": "sha256-bYbGxjYUyL5XLBIQoPxxw/n7yNQw+TH3rCoACAFcVZY=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c5e1362e46ace814fa50727c01846590d424c0ea",
+        "rev": "92d36e6bd89b685f32528fca7a2af055eb0d3487",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`92d36e6b`](https://github.com/nix-community/NUR/commit/92d36e6bd89b685f32528fca7a2af055eb0d3487) | `` automatic update `` |
| [`b0a7b04d`](https://github.com/nix-community/NUR/commit/b0a7b04d1b5941a17ca0e4b09ad2c520c08a9269) | `` automatic update `` |
| [`3df7256b`](https://github.com/nix-community/NUR/commit/3df7256bf6498033b550e6e665a06b4dfb0a6e47) | `` automatic update `` |
| [`e9ce7056`](https://github.com/nix-community/NUR/commit/e9ce70566e7ddd7be4868183951d5bb22bbf5618) | `` automatic update `` |
| [`65f74e2c`](https://github.com/nix-community/NUR/commit/65f74e2cd030b2475405b21a434588dc2fc8042e) | `` automatic update `` |
| [`2301a4f5`](https://github.com/nix-community/NUR/commit/2301a4f5571fb8f0f449d478de4d81cfa532f873) | `` automatic update `` |
| [`0cf1ed08`](https://github.com/nix-community/NUR/commit/0cf1ed08cfd4b550fd71092f8bb3cb064098c049) | `` automatic update `` |
| [`4c4b78ad`](https://github.com/nix-community/NUR/commit/4c4b78adae13c462669b4e5b62b9f10bf6bbb500) | `` automatic update `` |
| [`ac7aceca`](https://github.com/nix-community/NUR/commit/ac7aceca63c786be19d6cad0bed11cb02da7d9e3) | `` automatic update `` |