### PR TITLE
chore(flake/nur): `92d36e6b` -> `6115fd9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1754987913,
-        "narHash": "sha256-bYbGxjYUyL5XLBIQoPxxw/n7yNQw+TH3rCoACAFcVZY=",
+        "lastModified": 1755005751,
+        "narHash": "sha256-YFMuQop526IWvc2QvspShZ2ydUw3CBE6RL4T950QS5w=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "92d36e6bd89b685f32528fca7a2af055eb0d3487",
+        "rev": "6115fd9a51192a8c4c402a81ee657491e3661f9e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6115fd9a`](https://github.com/nix-community/NUR/commit/6115fd9a51192a8c4c402a81ee657491e3661f9e) | `` automatic update `` |
| [`d0dab324`](https://github.com/nix-community/NUR/commit/d0dab3248adc17eff8827ae2629c677deab3ed40) | `` automatic update `` |
| [`9294efad`](https://github.com/nix-community/NUR/commit/9294efadde942795fc1fd075617a53db9de3c285) | `` automatic update `` |
| [`7e5bf47a`](https://github.com/nix-community/NUR/commit/7e5bf47a4a5ed066ae47e6f421eb8b0d5c48ec8a) | `` automatic update `` |
| [`ccb6cee3`](https://github.com/nix-community/NUR/commit/ccb6cee3ff1f3b002d95144230d3908bcdf1b4d8) | `` automatic update `` |
| [`e213e2dd`](https://github.com/nix-community/NUR/commit/e213e2dd4275403f53643742974488890daa62b3) | `` automatic update `` |
| [`e39f53b0`](https://github.com/nix-community/NUR/commit/e39f53b0f73776d6cffe42e860e01a0e7fda8935) | `` automatic update `` |
| [`c2779e71`](https://github.com/nix-community/NUR/commit/c2779e71c6b68d2012f643a36c71ff4d3e1226da) | `` automatic update `` |
| [`86bd8299`](https://github.com/nix-community/NUR/commit/86bd82995b5141c9f44bf68b0b6040d67df3c5c3) | `` automatic update `` |
| [`292e6cd9`](https://github.com/nix-community/NUR/commit/292e6cd9467c0332a8708a4f3b448b38a22ebd8a) | `` automatic update `` |