### PR TITLE
chore(flake/nixpkgs): `c5f08b62` -> `ddae11e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754767907,
-        "narHash": "sha256-8OnUzRQZkqtUol9vuUuQC30hzpMreKptNyET2T9lB6g=",
+        "lastModified": 1754937576,
+        "narHash": "sha256-3sWA5WJybUE16kIMZ3+uxcxKZY/JRR4DFBqLdSLBo7w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5f08b62ed75415439d48152c2a784e36909b1bc",
+        "rev": "ddae11e58c0c345bf66efbddbf2192ed0e58f896",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`f50363b8`](https://github.com/NixOS/nixpkgs/commit/f50363b8bcf5cb529e6754485d56360b45fb53d5) | `` matrix-authentication-service: fix `http_listener_assets_path_default()` ``   |
| [`620be277`](https://github.com/NixOS/nixpkgs/commit/620be2770c8326b719da53793714deaad0ea5a16) | `` matrix-authentication-service: use substituteInPlace ``                       |
| [`52a04aef`](https://github.com/NixOS/nixpkgs/commit/52a04aef1706fbf5214de4957023284959b500b7) | `` workflows/build: build shells on a single darwin runner only ``               |
| [`fb86dcb5`](https://github.com/NixOS/nixpkgs/commit/fb86dcb57cc7227ccc99a386736fb370fbeb1b5e) | `` workflows/build: avoid downloading from cachix ``                             |
| [`41315a26`](https://github.com/NixOS/nixpkgs/commit/41315a269990c4f76afaf2eec42256d98c440ef1) | `` actions/get-merge-commit: bump actions/checkout to v5.0.0 ``                  |
| [`06c8d5c9`](https://github.com/NixOS/nixpkgs/commit/06c8d5c918e666c953976c608cff09f9ec170e60) | `` workflows: checkout pinned nixpkgs explicitly ``                              |
| [`15e17895`](https://github.com/NixOS/nixpkgs/commit/15e17895b53df365c6278157ab4b25c085fe1b81) | `` workflows: remove extra_nix_config.sandbox ``                                 |
| [`8a03e715`](https://github.com/NixOS/nixpkgs/commit/8a03e7155244bd41ebf8ddd7989278a4ed8ccf43) | `` build(deps): bump actions/create-github-app-token from 2.0.6 to 2.1.0 ``      |
| [`c3969b49`](https://github.com/NixOS/nixpkgs/commit/c3969b49ee2ac80a39791a725e270ad3143735db) | `` build(deps): bump actions/checkout from 4.2.2 to 5.0.0 ``                     |
| [`0962de4c`](https://github.com/NixOS/nixpkgs/commit/0962de4c4b1264b768863fb96cb6432c9d297396) | `` build(deps): bump actions/download-artifact from 4 to 5 ``                    |
| [`8704c567`](https://github.com/NixOS/nixpkgs/commit/8704c56787c66398901d008e47579ea6023f091c) | `` build(deps): bump cachix/install-nix-action from 31.4.1 to 31.5.2 ``          |
| [`0c86fe27`](https://github.com/NixOS/nixpkgs/commit/0c86fe2749120251f5f20d8bcd9bacbcc8d402d4) | `` librewolf-unwrapped: 141.0.2-1 -> 141.0.3-1 ``                                |
| [`1302c08c`](https://github.com/NixOS/nixpkgs/commit/1302c08ca71f65979f46bd9c51fee6a1eab94274) | `` draupnir: 2.5.0 -> 2.5.1 ``                                                   |
| [`64813207`](https://github.com/NixOS/nixpkgs/commit/64813207ad0b26bfb4b35156d4cd1adac5f790ba) | `` wlx-overlay-s: make openvr support optional, disable on aarch64-linux ``      |
| [`eba3d184`](https://github.com/NixOS/nixpkgs/commit/eba3d184d02f0ad23ddf531e4bc46a3eb64cf25e) | `` capnproto: fix fibers on static builds ``                                     |
| [`dbcd03ec`](https://github.com/NixOS/nixpkgs/commit/dbcd03ecba6e9d7fea11b7c2e0c4ce0fbd562b0e) | `` sydbox: 3.37.2 -> 3.37.6 ``                                                   |
| [`b614aa69`](https://github.com/NixOS/nixpkgs/commit/b614aa6936eed86135678f8a4541d16a3fbdca9b) | `` linuxPackages.openafs: Patch for Linux kernel 6.16 ``                         |
| [`3871b622`](https://github.com/NixOS/nixpkgs/commit/3871b622bdb1647db1f7b552f45dd620ec7f236e) | `` google-chrome: 138.0.7204.183 -> 139.0.7258.66 ``                             |
| [`1910b6d3`](https://github.com/NixOS/nixpkgs/commit/1910b6d3138ca601d37913f71e593c4f06d185e7) | `` postgresqlPackages.pg_net: 0.19.4 -> 0.19.5 ``                                |
| [`62750501`](https://github.com/NixOS/nixpkgs/commit/6275050154ddc3a1da600ea2298371dd94496470) | `` workflows/pr: run in pull_request context to test actions/get-merge-commit `` |
| [`0142a8b5`](https://github.com/NixOS/nixpkgs/commit/0142a8b5c07bf409d38e19d647abc7f3a2f7fc1d) | `` omnisharp-roslyn: 1.39.13 -> 1.39.14 ``                                       |
| [`7174fa21`](https://github.com/NixOS/nixpkgs/commit/7174fa21e87a50cb39850c7f5eaa4c571fd9d4b4) | `` ollama: unbreak on darwin by using apple-sdk_15 ``                            |
| [`435b9d1c`](https://github.com/NixOS/nixpkgs/commit/435b9d1c88e27afcca599938c0eda31f8d9414f0) | `` ollama: 0.11.3 -> 0.11.4 ``                                                   |
| [`c50a7711`](https://github.com/NixOS/nixpkgs/commit/c50a771166cc94658b9d3ec51ad88c43e039250c) | `` ollama: mark as broken on darwin ``                                           |
| [`bbbaef9f`](https://github.com/NixOS/nixpkgs/commit/bbbaef9fcc5af2bd0c6b273579d4db4c5f6da2be) | `` ollama: 0.11.0 -> 0.11.3 ``                                                   |
| [`94f0ca64`](https://github.com/NixOS/nixpkgs/commit/94f0ca6417f1a2f2fed2b036cd92a99497abb55f) | `` ollama: fix source hash for version 0.11.0 ``                                 |
| [`0978efac`](https://github.com/NixOS/nixpkgs/commit/0978efaceb59560b253a110b7f395242529b3f77) | `` ollama: 0.10.0 -> 0.11.0 ``                                                   |
| [`946f9447`](https://github.com/NixOS/nixpkgs/commit/946f9447c7ccb0671eb0e4fe11e61ee2c05605ab) | `` ollama: 0.9.6 -> 0.10.0 ``                                                    |
| [`8452b40e`](https://github.com/NixOS/nixpkgs/commit/8452b40e025b8a40696f63e8a7832581767732f4) | `` linuxKernel.kernels.linux_zen: 6.15.8 -> 6.16 ``                              |
| [`72ac545c`](https://github.com/NixOS/nixpkgs/commit/72ac545c716ad3005fe527b0622650cb4e23b9f8) | `` dotnetCorePackages.dotnet_9.vmr: 9.0.7 -> 9.0.8 ``                            |
| [`efceb910`](https://github.com/NixOS/nixpkgs/commit/efceb9101c02eefaf9c1399fe67979b9a998a693) | `` dotnetCorePackages.dotnet_8.vmr: 8.0.18 -> 8.0.19 ``                          |
| [`0f24b748`](https://github.com/NixOS/nixpkgs/commit/0f24b748f65cb6a1a62129f5559cf0e69d043c5a) | `` dotnetCorePackages.sdk_9_0-bin: 9.0.303 -> 9.0.304 ``                         |
| [`e242348b`](https://github.com/NixOS/nixpkgs/commit/e242348b5ab6931e6307a40af857a9fac44d2667) | `` dotnetCorePackages.sdk_8_0-bin: 8.0.412 -> 8.0.413 ``                         |
| [`be2cecf0`](https://github.com/NixOS/nixpkgs/commit/be2cecf0bd688f7f1cfdb4b2a2fc1a2a5eb8bd9a) | `` ed-odyssey-materials-helper: 2.199 -> 2.223 ``                                |
| [`687b1be9`](https://github.com/NixOS/nixpkgs/commit/687b1be939c033a1aaa1fb7251f51f2990b75a00) | `` apacheKafka: 3_7: 3.7.1 → 3.7.2 ``                                            |
| [`a5451b54`](https://github.com/NixOS/nixpkgs/commit/a5451b54616f4d4c2bf63fa6c85ddb12fb0175c1) | `` apacheKafka: 3_9: 3.9.0 → 3.9.1 ``                                            |
| [`4316862e`](https://github.com/NixOS/nixpkgs/commit/4316862eeb5c271cecbc1f4baf269ca20f83755c) | `` apacheHttpd: 2.6.62 -> 2.6.65 ``                                              |
| [`1fc4e150`](https://github.com/NixOS/nixpkgs/commit/1fc4e150ed415250163a6c604a8f4120980c567b) | `` protoc-gen-grpc-java: init at 1.73.0 (#415329) ``                             |
| [`0142dc55`](https://github.com/NixOS/nixpkgs/commit/0142dc559c0524a4d4a1f0c6ac028f4b102b00ff) | `` nebula: 1.9.5 -> 1.9.6 ``                                                     |
| [`a5ce3f38`](https://github.com/NixOS/nixpkgs/commit/a5ce3f388e43ed09edcb2c1b446034ce273ce5db) | `` vmware-workstation: 17.6.3 -> 17.6.4 ``                                       |