### PR TITLE
chore(flake/nur): `6115fd9a` -> `3efcaa18`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755005751,
-        "narHash": "sha256-YFMuQop526IWvc2QvspShZ2ydUw3CBE6RL4T950QS5w=",
+        "lastModified": 1755017634,
+        "narHash": "sha256-pgH8wqjXQmIshC7zy5lImEd6tK1cmS/telTW3fXDOdg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "6115fd9a51192a8c4c402a81ee657491e3661f9e",
+        "rev": "3efcaa18559af47fa3937b8aeee532cd6aebf354",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                                  |
| -------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`3efcaa18`](https://github.com/nix-community/NUR/commit/3efcaa18559af47fa3937b8aeee532cd6aebf354) | `` feat: Add the-code-fixer-23 repository. ``            |
| [`93428a07`](https://github.com/nix-community/NUR/commit/93428a071b1afb75886101966aaff9592b88e3bb) | `` automatic update ``                                   |
| [`62236c6f`](https://github.com/nix-community/NUR/commit/62236c6fe8323ea4d57d3b6999e561e4313b7787) | `` Update cachix/install-nix-action digest to c134e4c `` |
| [`2f3a4cbb`](https://github.com/nix-community/NUR/commit/2f3a4cbb2fd463b62c537b97f8321c1406a75399) | `` Update actions/checkout action to v5 ``               |
| [`256aa773`](https://github.com/nix-community/NUR/commit/256aa77335ca48c57d23dd86dddd3ed962fa9a13) | `` automatic update ``                                   |
| [`14fd5ce6`](https://github.com/nix-community/NUR/commit/14fd5ce6e2799015cc396210aa96d2f179768478) | `` automatic update ``                                   |
| [`bbfdb776`](https://github.com/nix-community/NUR/commit/bbfdb7764fd1045e525703449e7e29f957e28c0d) | `` automatic update ``                                   |
| [`310ee225`](https://github.com/nix-community/NUR/commit/310ee225d78767abda1f86de23444e8172c777cb) | `` automatic update ``                                   |