### PR TITLE
chore(flake/nur): `109080b6` -> `b6b0f138`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755031278,
-        "narHash": "sha256-flnsYgfvL6qeoKZpcB7YIAuWO3HUaXq1bBKN4Mgu+DA=",
+        "lastModified": 1755052263,
+        "narHash": "sha256-Ej66AAtBHH6MAz8+vN9LxHis+IqTyNucZhhy9yBEf5I=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "109080b61db30927ac762cf1a941a56901cb9362",
+        "rev": "b6b0f138a9a44a158773799eacabce3c044c16e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b6b0f138`](https://github.com/nix-community/NUR/commit/b6b0f138a9a44a158773799eacabce3c044c16e4) | `` automatic update `` |
| [`11d4ac71`](https://github.com/nix-community/NUR/commit/11d4ac71bea6522909e910275f995e470b3e9e9f) | `` automatic update `` |
| [`c625bacd`](https://github.com/nix-community/NUR/commit/c625bacd9520fd974bdbf80833ca07bd68cb1085) | `` automatic update `` |
| [`31817932`](https://github.com/nix-community/NUR/commit/31817932791bbe3fcaf3e2dfeb95b5ce83444b59) | `` automatic update `` |
| [`1b5eb5a3`](https://github.com/nix-community/NUR/commit/1b5eb5a353fa39c32b39c6398cca1d55d91351d6) | `` automatic update `` |
| [`582b4906`](https://github.com/nix-community/NUR/commit/582b490660486ff1d28dc21177c41cd3bfcc386a) | `` automatic update `` |
| [`f4278df5`](https://github.com/nix-community/NUR/commit/f4278df58ceab625130771a14625a92c093fb9ff) | `` automatic update `` |
| [`dd2283fd`](https://github.com/nix-community/NUR/commit/dd2283fdb79ecea807a6c78b75034a07b63112be) | `` automatic update `` |
| [`2fed886f`](https://github.com/nix-community/NUR/commit/2fed886f7d7f599754dd54a5c6d21e38d3227f69) | `` automatic update `` |