### PR TITLE
chore(flake/nur): `b6b0f138` -> `12e0a076`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755052263,
-        "narHash": "sha256-Ej66AAtBHH6MAz8+vN9LxHis+IqTyNucZhhy9yBEf5I=",
+        "lastModified": 1755058983,
+        "narHash": "sha256-QgYmkYQ6Z7BOxLGcPIZOyOCcUknup9TxB2dkJMo7bIU=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "b6b0f138a9a44a158773799eacabce3c044c16e4",
+        "rev": "12e0a076c59db91706ef06aec2271d747feec61f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`12e0a076`](https://github.com/nix-community/NUR/commit/12e0a076c59db91706ef06aec2271d747feec61f) | `` automatic update `` |
| [`142aa7b9`](https://github.com/nix-community/NUR/commit/142aa7b9734d5434c958966315547d44afe65b3b) | `` automatic update `` |
| [`745d250d`](https://github.com/nix-community/NUR/commit/745d250d5fe6d5996eb121a9b355b289937dc5f1) | `` automatic update `` |