### PR TITLE
chore(flake/nur): `12e0a076` -> `b68a7eaf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755058983,
-        "narHash": "sha256-QgYmkYQ6Z7BOxLGcPIZOyOCcUknup9TxB2dkJMo7bIU=",
+        "lastModified": 1755074489,
+        "narHash": "sha256-xc5Ob3jufe3t768LkttWYvDD9xUwTyk332jP2rrBGsM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "12e0a076c59db91706ef06aec2271d747feec61f",
+        "rev": "b68a7eafeaf02b2d5b184da21115ad9703b77386",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b68a7eaf`](https://github.com/nix-community/NUR/commit/b68a7eafeaf02b2d5b184da21115ad9703b77386) | `` automatic update `` |
| [`76fa5604`](https://github.com/nix-community/NUR/commit/76fa560478c3f335d8196f5020a73c5e80f1e641) | `` automatic update `` |
| [`d3072576`](https://github.com/nix-community/NUR/commit/d3072576a06d246f06ae0d29b89a1e8998e02150) | `` automatic update `` |
| [`eee5d4c1`](https://github.com/nix-community/NUR/commit/eee5d4c1c3d6994b7690bde15e81959979960440) | `` automatic update `` |
| [`3352304d`](https://github.com/nix-community/NUR/commit/3352304d8f256bb67b5f9662b3493b069b3cac25) | `` automatic update `` |
| [`32d9e69e`](https://github.com/nix-community/NUR/commit/32d9e69e03ee1ea8e2b63110e41e15bb694a32ce) | `` automatic update `` |
| [`b4ffc0f3`](https://github.com/nix-community/NUR/commit/b4ffc0f36e699b9ae438ec03a74ecf535c53745a) | `` automatic update `` |
| [`45cad53f`](https://github.com/nix-community/NUR/commit/45cad53fd100ec01b300770915f181b441456562) | `` automatic update `` |