### PR TITLE
chore(flake/nur): `2c7b4bfa` -> `94c6c5b9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -477,11 +477,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1754725699,
-        "narHash": "sha256-iAcj9T/Y+3DBy2J0N+yF9XQQQ8IEb5swLFzs23CdP88=",
+        "lastModified": 1755027561,
+        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "85dbfc7aaf52ecb755f87e577ddbe6dbbdbc1054",
+        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755091088,
-        "narHash": "sha256-KGFdiQdhWQWpBLIifhT0ytMi3A2z/IBP66BIKRp5K9Q=",
+        "lastModified": 1755102471,
+        "narHash": "sha256-ecWsZvrU/v7phSRIulxUYoCZ+i8s+mQ0ecmxxcgHUko=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "2c7b4bfad3493d29b149b85ed32d6f3f44b69746",
+        "rev": "94c6c5b9798480dc220ee2cc8b1ce93a472a8d8f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`94c6c5b9`](https://github.com/nix-community/NUR/commit/94c6c5b9798480dc220ee2cc8b1ce93a472a8d8f) | `` automatic update `` |
| [`91c6ddfb`](https://github.com/nix-community/NUR/commit/91c6ddfbb2f60ba7d7c3b0ffa65d7f46c3910a56) | `` automatic update `` |
| [`13ab153a`](https://github.com/nix-community/NUR/commit/13ab153a293ec447f34a706ed4017d7159d50b88) | `` automatic update `` |
| [`bfde2fa7`](https://github.com/nix-community/NUR/commit/bfde2fa7f9006dd51de160f26d46fcbc5dfe1956) | `` add lmdevv repo ``  |
| [`0125fb52`](https://github.com/nix-community/NUR/commit/0125fb522b83065470de30bbbac660208ca593aa) | `` automatic update `` |