### PR TITLE
chore(flake/nixpkgs): `ddae11e5` -> `3385ca0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1754937576,
-        "narHash": "sha256-3sWA5WJybUE16kIMZ3+uxcxKZY/JRR4DFBqLdSLBo7w=",
+        "lastModified": 1755078291,
+        "narHash": "sha256-Hu/gTDoi4uy6TAKISPHQusSMy8U6xUbLSDjKBYdhDIY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ddae11e58c0c345bf66efbddbf2192ed0e58f896",
+        "rev": "3385ca0cd7e14c1a1eb80401fe011705ff012323",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`7c27ce05`](https://github.com/NixOS/nixpkgs/commit/7c27ce05a1b2c6b73a2d69b16f77d9f13775eda5) | `` fstar: fix installation of OCaml libraries ``                    |
| [`dfe90eaa`](https://github.com/NixOS/nixpkgs/commit/dfe90eaaa8a5394f6abca5d28504c8e6421f973e) | `` proton-ge-bin: GE-Proton10-10 -> GE-Proton10-11 ``               |
| [`16f44385`](https://github.com/NixOS/nixpkgs/commit/16f4438573f5e0945c0b54332ba01d6436dc2ede) | `` proton-ge-bin: GE-Proton10-9 -> GE-Proton10-10 ``                |
| [`0c12b62e`](https://github.com/NixOS/nixpkgs/commit/0c12b62e33f2fd04d3afade3efefe897b7eb3223) | `` rustdesk-flutter: 1.4.0 -> 1.4.1 ``                              |
| [`80664ff1`](https://github.com/NixOS/nixpkgs/commit/80664ff1eacc14c21e1ba16d907bf13b4d4d78a5) | `` rustdesk-flutter: 1.3.9 -> 1.4.0 ``                              |
| [`b260694a`](https://github.com/NixOS/nixpkgs/commit/b260694aa7710ab7df934fde1d5193828a4d9d61) | `` lockbook-desktop: 0.9.25 -> 0.9.26 ``                            |
| [`28d4fd65`](https://github.com/NixOS/nixpkgs/commit/28d4fd65736d21208004a761dd31470e2c26c1ea) | `` lockbook: 0.9.25 -> 0.9.26 ``                                    |
| [`f7761f36`](https://github.com/NixOS/nixpkgs/commit/f7761f3692b3f0abf6a1b1a5c91bbe2ba869a97e) | `` draupnir: 2.5.1 -> 2.6.0 ``                                      |
| [`f05c8ddf`](https://github.com/NixOS/nixpkgs/commit/f05c8ddfd76ef7f749e5e2d33c0a683374c6f423) | `` ci/default: remove insecure Nix 2.3 config ``                    |
| [`c6efa352`](https://github.com/NixOS/nixpkgs/commit/c6efa35204dbc8cf2fcb8d28a6b2591c60119eb5) | `` lib/tests: don't test with Nix 2.3 anymore ``                    |
| [`521fd9bc`](https://github.com/NixOS/nixpkgs/commit/521fd9bcd1f43276aba723ddc171c54601499177) | `` workflows/check: allow more time for check cherry picks job ``   |
| [`cf95e395`](https://github.com/NixOS/nixpkgs/commit/cf95e395ecb4e7ba38ae92631e357c4e703a2a7d) | `` archipelago: 0.6.2 -> 0.6.3 ``                                   |
| [`3bc8302a`](https://github.com/NixOS/nixpkgs/commit/3bc8302a6aa1bd91504014b986d7aa7ac7d8e986) | `` workflows/pr: fix condition for no-pr-failures job ``            |
| [`eec72ea6`](https://github.com/NixOS/nixpkgs/commit/eec72ea6e4aba8c8ba321a5926b76b43ca2d4021) | `` workflows/pr: block merging PRs when jobs have been cancelled `` |
| [`56022d77`](https://github.com/NixOS/nixpkgs/commit/56022d779d95bf7726b6602ef116fea823baca18) | `` workflows/eval: fix compare job not running ``                   |
| [`835136c9`](https://github.com/NixOS/nixpkgs/commit/835136c988b6ea5564c5db499a5f419a5aef126e) | `` workflows/backport: fix token permissions ``                     |
| [`ad0e8bc1`](https://github.com/NixOS/nixpkgs/commit/ad0e8bc1904bcbe5d957819d98c89d984563fb07) | `` ci/pinned: update ``                                             |
| [`0262bcdd`](https://github.com/NixOS/nixpkgs/commit/0262bcddf288ec6b59890bd26c3a0cfa94d3c8c9) | `` workflows/eval: test all available versions ``                   |
| [`446ff34e`](https://github.com/NixOS/nixpkgs/commit/446ff34e113ed0ecbd5286577367c375206b694b) | `` ci/eval/compare: reorder step summary ``                         |
| [`7693833e`](https://github.com/NixOS/nixpkgs/commit/7693833eeb943fca766f6a27f6d6979ebccd7003) | `` workflows: fix actions/download-artifact hashes ``               |
| [`4e2fc116`](https://github.com/NixOS/nixpkgs/commit/4e2fc116bebf89c08b55810842949f40be900b7d) | `` ocamlPackages.mdx: add missing dependency to result ``           |
| [`09624d8f`](https://github.com/NixOS/nixpkgs/commit/09624d8fc277b8a4026be7be1bc88149a11565e2) | `` julia_111: 1.11.5 -> 1.11.6 ``                                   |
| [`bfdd7206`](https://github.com/NixOS/nixpkgs/commit/bfdd7206eb81a204ba9de4962bc62997325233fe) | `` julia_111-bin: 1.11.5 -> 1.11.6 ``                               |
| [`6c1a96ba`](https://github.com/NixOS/nixpkgs/commit/6c1a96bac08c8d265f8c79be6f0c7ecf3a2bb3f7) | `` easycrypt: 2025.03 -> 2025.08 ``                                 |
| [`5d26a491`](https://github.com/NixOS/nixpkgs/commit/5d26a491ffd9b49a40f4e026ca4f53f312f19d93) | `` element-web-unwrapped: 1.11.108 -> 1.11.109 ``                   |
| [`c4765805`](https://github.com/NixOS/nixpkgs/commit/c476580515177e9b7221f22dbdb98ade8542f005) | `` element-desktop: 1.11.108 -> 1.11.109 ``                         |
| [`f8822432`](https://github.com/NixOS/nixpkgs/commit/f8822432d9b5f1c3e1ec84b6b6fee5126b964b8c) | `` matrix-synapse: 1.135.0 -> 1.135.2 ``                            |
| [`e4570d16`](https://github.com/NixOS/nixpkgs/commit/e4570d168ef6d534a61eaab765ed41a548788822) | `` dependency-track: 4.13.2 -> 4.13.3 ``                            |
| [`0ff8a8e1`](https://github.com/NixOS/nixpkgs/commit/0ff8a8e1c953cbdd84c07457321059eccf0a8c8a) | `` shellhub-agent: 0.19.2 -> 0.20.0 ``                              |
| [`c1f9b449`](https://github.com/NixOS/nixpkgs/commit/c1f9b449c3967c1e57106c03ecea25ab5fa6f3b7) | `` veilid: 0.4.7 -> 0.4.8 ``                                        |
| [`6b445c19`](https://github.com/NixOS/nixpkgs/commit/6b445c19c41203c268d8354e0a811b880a5e8236) | `` xen: 4.19.3-unstable-2025-07-09 -> 4.19.3 ``                     |