### PR TITLE
chore(flake/spicetify-nix): `fcbfc215` -> `7d103eb1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -571,11 +571,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1754801101,
-        "narHash": "sha256-oxWjZ/SfhCvHFNePZcUu+LcE5j4xxuIt/yaoaSvMZk0=",
+        "lastModified": 1755213943,
+        "narHash": "sha256-ssLRCiwcdkioOg9swgU2+PIhTR5SABnJxjTtaqbzPLo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "fcbfc21572518c68317df992929b28df9a1d8468",
+        "rev": "7d103eb173df0937a0a02f40692c018297cfb241",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                 |
| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`7d103eb1`](https://github.com/Gerg-L/spicetify-nix/commit/7d103eb173df0937a0a02f40692c018297cfb241) | `` fix(deps): update all non-major dependencies ``      |
| [`f2ac22a6`](https://github.com/Gerg-L/spicetify-nix/commit/f2ac22a633d5d8781719c616cd3a6b06b5982aa8) | `` chore(deps): update actions/checkout action to v5 `` |