### PR TITLE
chore(flake/chaotic): `5efc0389` -> `766a5763`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755169038,
-        "narHash": "sha256-lIAE8ou7ukvoOE0nZ2lNcl/n8mnj6m2cGsx9U7Xhew4=",
+        "lastModified": 1755261355,
+        "narHash": "sha256-RQVhOuwfLSB64CMv8GMfBFZ2PXmIVleZeZskItqgD5o=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "5efc0389eaca14046e1ee2068bcba6fe64cf6e2e",
+        "rev": "766a57635e5afd201c5d918087e5f9c9f63bfed1",
         "type": "github"
       },
       "original": {
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755027561,
-        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                             |
| ----------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`766a5763`](https://github.com/chaotic-cx/nyx/commit/766a57635e5afd201c5d918087e5f9c9f63bfed1) | `` failures: update x86_64-linux `` |
| [`e31adaf6`](https://github.com/chaotic-cx/nyx/commit/e31adaf66a72f775785a33668dd03dc01667e2ec) | `` nixpkgs: bump to 20250815 ``     |
| [`e5e35ed4`](https://github.com/chaotic-cx/nyx/commit/e5e35ed4e5a6433f3d90dcabf3dd2cd8ba36a9eb) | `` Bump 20250814-2 (#1148) ``       |