### PR TITLE
chore(flake/nixpkgs-unstable): `005433b9` -> `fbcf476f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -350,11 +350,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1755027561,
-        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`743db0d1`](https://github.com/NixOS/nixpkgs/commit/743db0d19fd0dc29cedf9454c40102fd51dbfae2) | `` lagrange: 1.18.6 -> 1.18.7 ``                                          |
| [`e102e8f6`](https://github.com/NixOS/nixpkgs/commit/e102e8f63bc81ad5189bf380fdeb72e942c29c23) | `` reprepro: init at 5.4.7 ``                                             |
| [`e74dccab`](https://github.com/NixOS/nixpkgs/commit/e74dccabaa0f3c0c7408947ac3262ee5ce382f6c) | `` cosmic-protocols: 0-unstable-2025-08-04 -> 0-unstable-2025-08-12 ``    |
| [`00c7fe10`](https://github.com/NixOS/nixpkgs/commit/00c7fe10b065cc58cac58447155eb029e1d5d6e3) | `` space-station-14-launcher: 0.32.1 -> 0.33.0 ``                         |
| [`d63b6cdb`](https://github.com/NixOS/nixpkgs/commit/d63b6cdb3efa9f6d999a29dbd6f76c5a903cd6b0) | `` tailwindcss_4: 4.1.11 -> 4.1.12 ``                                     |
| [`85875791`](https://github.com/NixOS/nixpkgs/commit/858757916f03c787a83bb90b0eb2dcebe1e051da) | `` python312Packages.youtube-transcript-api: 1.0.3 -> 1.2.2 (#430785) ``  |
| [`4d5489dd`](https://github.com/NixOS/nixpkgs/commit/4d5489ddbafb0d4234aca92019fa6be5cc96dabe) | `` _3cpio: 0.8.0 -> 0.10.2 ``                                             |
| [`961f0bc0`](https://github.com/NixOS/nixpkgs/commit/961f0bc0da5b2875d7795ac9d92c05a4e9cfd4eb) | `` libretro.beetle-psx: 0-unstable-2025-08-01 -> 0-unstable-2025-08-06 `` |
| [`95452e87`](https://github.com/NixOS/nixpkgs/commit/95452e879714249c34dbd9c39dfc36511a03b450) | `` nixos/onlyoffice: fix gixy error (#419765) ``                          |
| [`87499d4f`](https://github.com/NixOS/nixpkgs/commit/87499d4fba47b8fd0a1cf7847735144ed60ead48) | `` python3Packages.dataclass-csv: init at 1.4.0 ``                        |
| [`69ccc37f`](https://github.com/NixOS/nixpkgs/commit/69ccc37f2cfb8781db4e64f7776761f41109358d) | `` python3Packages.symbolic: 12.16.1 -> 12.16.2 ``                        |
| [`e5f5e406`](https://github.com/NixOS/nixpkgs/commit/e5f5e4064233e94dd99fc5ef7afc81fda99f7b11) | `` nixForLinking: drop alias ``                                           |
| [`91884663`](https://github.com/NixOS/nixpkgs/commit/91884663a6ef75489a506d80b6c422220e791e3c) | `` app2unit: 1.0.0 -> 1.0.3 ``                                            |
| [`9bc4e5fd`](https://github.com/NixOS/nixpkgs/commit/9bc4e5fd583da604737bac1076167646b743bdff) | `` opam: 2.4.0 -> 2.4.1 ``                                                |
| [`4d2c18b7`](https://github.com/NixOS/nixpkgs/commit/4d2c18b7df1a3990c1da6f24d35f673629c72592) | `` opam: 2.3.0 -> 2.4.0 ``                                                |
| [`4ae8242f`](https://github.com/NixOS/nixpkgs/commit/4ae8242fb8473ea1d68d88814cd0435e499ab9b0) | `` ocamlPackages.patch: 2.0.0 -> 3.0.0 ``                                 |
| [`b178b8c4`](https://github.com/NixOS/nixpkgs/commit/b178b8c45de5fc11a4635dbe0c6d5bc30ab31f57) | `` affine: 0.23.2 -> 0.24.0 ``                                            |
| [`05aa542b`](https://github.com/NixOS/nixpkgs/commit/05aa542b17ec054f207610c1dd10066d6151a7cd) | `` home-assistant-custom-components.octopus_energy: init at 16.0.2 ``     |
| [`bb578c92`](https://github.com/NixOS/nixpkgs/commit/bb578c929783a46026cc3cdf450e34a1602a1336) | `` svelte-language-server: 0.17.17 -> 0.17.19 ``                          |
| [`e6270554`](https://github.com/NixOS/nixpkgs/commit/e627055445d500843b562a58eb429f12fce13f6e) | `` python3Packages.influxdb3-python: 0.14.0 -> 0.15.0 ``                  |
| [`34485658`](https://github.com/NixOS/nixpkgs/commit/344856580f9b09516dd5653e14294d659c0b3bc4) | `` postgresqlPackages.pg-gvm: 22.6.10 -> 22.6.11 ``                       |
| [`67656c9d`](https://github.com/NixOS/nixpkgs/commit/67656c9d3b36f02d9d4fbd0bd0fc2bb8c281418f) | `` nix-serve: 2024-09-18 -> 2024-09-20 ``                                 |
| [`1a89f3c5`](https://github.com/NixOS/nixpkgs/commit/1a89f3c5bbd382ae2d216765bc3dfa9c338c97d3) | `` nixos-rebuild: bump oldest supported nix version to 2_28 ``            |
| [`75a97f79`](https://github.com/NixOS/nixpkgs/commit/75a97f79c2f52fffe4e098c2c6a01b4b60fc632c) | `` gruvbox-plus-icons: 6.2.0 -> 6.3.0 ``                                  |
| [`a9642e9c`](https://github.com/NixOS/nixpkgs/commit/a9642e9c15719724a02682676dd390cd18d75503) | `` vault-bin: 1.20.1 -> 1.20.2 ``                                         |
| [`9a0874b0`](https://github.com/NixOS/nixpkgs/commit/9a0874b0bb6d5a35f40c39e8ad56a3e5e9e2ce30) | `` screenly-cli: 1.0.3 -> 1.0.4 ``                                        |
| [`34a71199`](https://github.com/NixOS/nixpkgs/commit/34a71199b028cb23fd3d65d1327adfa8dd5436fa) | `` python3Packages.finetuning-scheduler: skip failing test ``             |
| [`ba78835e`](https://github.com/NixOS/nixpkgs/commit/ba78835ed91b1d7946e4f17c107bb6edc65f9497) | `` doc/python: fix commit prefix instructions (refer to pkgs/README) ``   |
| [`71db3b58`](https://github.com/NixOS/nixpkgs/commit/71db3b58fc97fd513bec431fd4ec0592d2e292cf) | `` velocity: 3.4.0-unstable-2025-08-02 -> 3.4.0-unstable-2025-08-13 ``    |
| [`b02f2218`](https://github.com/NixOS/nixpkgs/commit/b02f2218db4c51a7654b59406a79845ca01ee9d9) | `` postgresqlPackages.timescaledb: 2.21.2 -> 2.21.3 ``                    |
| [`d7f5793e`](https://github.com/NixOS/nixpkgs/commit/d7f5793ecaef8d7041da4b50ef251891593f1e1a) | `` python313Packages.nclib: refactor ``                                   |
| [`06a98f6d`](https://github.com/NixOS/nixpkgs/commit/06a98f6d87afc76e7b3ea554ef97a30d4664a298) | `` qlementine-icons: 1.10.0 -> 1.11.0 ``                                  |
| [`5956f328`](https://github.com/NixOS/nixpkgs/commit/5956f328e2eaab43dfc40e4c63259a83eb344198) | `` libphonenumber: allow building without openjdk ``                      |
| [`c40ccbcd`](https://github.com/NixOS/nixpkgs/commit/c40ccbcd4624e3d901e8067b9a69194b3c8fed4b) | `` libphonenumber: 9.0.10 -> 9.0.12 ``                                    |
| [`137af273`](https://github.com/NixOS/nixpkgs/commit/137af2736a9a24098d4734999ec9375fc84e8bf8) | `` corsix-th: 0.69.0 -> 0.69.1 ``                                         |
| [`0c3f9e56`](https://github.com/NixOS/nixpkgs/commit/0c3f9e56a516ac665481f32034b44ae648f34da8) | `` python3Packages.metaflow: 2.16.8 -> 2.17.1 ``                          |
| [`8f8aadc2`](https://github.com/NixOS/nixpkgs/commit/8f8aadc2d4c1ce1f858fd8b059b5dd14deae2b2a) | `` claude-code: 1.0.74 -> 1.0.80 ``                                       |
| [`0934d965`](https://github.com/NixOS/nixpkgs/commit/0934d9650897f21d297740775c624378c632fb58) | `` ocamlPackages.lwd: 0.3 → 0.4 ``                                        |
| [`b1e23295`](https://github.com/NixOS/nixpkgs/commit/b1e23295965fd4c30e5dcdb2a8712434a0f8437c) | `` python3Packages.nclib: 1.0.5 -> 1.0.7 ``                               |
| [`07a74cb8`](https://github.com/NixOS/nixpkgs/commit/07a74cb8891038c42d56ff619a8267bfabc5a8e5) | `` arkenfox-userjs: 133.0 -> 140.0 ``                                     |
| [`94e77bbf`](https://github.com/NixOS/nixpkgs/commit/94e77bbf942516127916eca971c677dc6774c352) | `` jfrog-cli: 2.78.2 -> 2.78.3 ``                                         |
| [`d2d5944f`](https://github.com/NixOS/nixpkgs/commit/d2d5944f8b011e3ff05e5a23703fe5252589ee6f) | `` hoppscotch: 25.7.0-0 -> 25.7.1-0 ``                                    |
| [`20f95217`](https://github.com/NixOS/nixpkgs/commit/20f95217d5e15d8f4597c1079e5ffa9394f2b8bd) | `` vimPlugins.fine-cmdline-nvim: init at 2025-06-15 ``                    |
| [`a00ce53c`](https://github.com/NixOS/nixpkgs/commit/a00ce53c43338806925ce6fd371e7c3432c3c655) | `` home-assistant: update component packages ``                           |
| [`6cb7f918`](https://github.com/NixOS/nixpkgs/commit/6cb7f918fcd1104bce96443f1ae04682567ebe4e) | `` python3Packages.python-etherscan-api: init at 2.1.0 ``                 |
| [`07254f9a`](https://github.com/NixOS/nixpkgs/commit/07254f9ae2847ba81a84114a3a0be70423d475bf) | `` home-assistant: update component packages ``                           |
| [`72417d37`](https://github.com/NixOS/nixpkgs/commit/72417d379135d2b6ac73285fccf2ed0e5d9f1cdc) | `` python3Packages.rtmapi: init at 0.7.2 ``                               |
| [`4d6b60f6`](https://github.com/NixOS/nixpkgs/commit/4d6b60f6e41fcef5b29f8c2a6087e4e6578f8cd9) | `` golangci-lint: 2.3.1 -> 2.4.0 ``                                       |
| [`bd9ce9a3`](https://github.com/NixOS/nixpkgs/commit/bd9ce9a3541fbe5b8521eacbe5517c74c117cdd2) | `` zed-editor: 0.198.6 -> 0.199.6 ``                                      |
| [`490a96b1`](https://github.com/NixOS/nixpkgs/commit/490a96b16b745c784d212c13ac05ec40ed9eea80) | `` nvrh: no go version substitution in go.mod ``                          |
| [`b6ee8514`](https://github.com/NixOS/nixpkgs/commit/b6ee8514e5270baa18ee03d747726c7a4df17e0f) | `` fosrl-newt: 1.4.0 -> 1.4.1 ``                                          |
| [`c1385977`](https://github.com/NixOS/nixpkgs/commit/c1385977e0aa68fc2a4510b44b6ad0d10b7eca45) | `` fosrl-olm: 1.0.0 -> 1.1.0 ``                                           |
| [`f2fddfa6`](https://github.com/NixOS/nixpkgs/commit/f2fddfa6bac0167563d7fbcbbae2395b88d08e7d) | `` kubernetes-helm: 3.18.4 -> 3.18.5 ``                                   |
| [`c42bf016`](https://github.com/NixOS/nixpkgs/commit/c42bf01655c5a46f5e352e40e428ec51acdceabf) | `` galene: 0.96.3 -> 1.0 ``                                               |
| [`9181b84b`](https://github.com/NixOS/nixpkgs/commit/9181b84b1d109d4fbe0080149c33f59bf78c3bad) | `` slock: 1.5 -> 1.6 ``                                                   |
| [`1a0fbf20`](https://github.com/NixOS/nixpkgs/commit/1a0fbf205b5f9faea514cda99dc282a7ff1752ba) | `` wakatime-cli: 1.129.1 -> 1.130.1 ``                                    |
| [`45e24e83`](https://github.com/NixOS/nixpkgs/commit/45e24e83c407929dbe8c4784d4b963ddf475ec37) | `` nixos/lanraragi: update description ``                                 |
| [`c4d07764`](https://github.com/NixOS/nixpkgs/commit/c4d077646b4a147fa239a2a099730019e09ce79d) | `` dmenu: 5.3 -> 5.4 ``                                                   |