### PR TITLE
chore(flake/nur): `178b145b` -> `861cbfb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755264546,
-        "narHash": "sha256-Wn+dwZGh/IH2PksY0hdGYMim7TX5j7tBpyG79FpmYa8=",
+        "lastModified": 1755276415,
+        "narHash": "sha256-y+OB105ElTRgPG8bJaRwiM0nCYAdV3JFyy5F/1uBUC4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "178b145b2210ac79b885fb424cc40a4026960bd3",
+        "rev": "861cbfb2b7ea21769ad0cedc24674f7dd0301a6b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`861cbfb2`](https://github.com/nix-community/NUR/commit/861cbfb2b7ea21769ad0cedc24674f7dd0301a6b) | `` automatic update `` |
| [`fc918348`](https://github.com/nix-community/NUR/commit/fc9183488110d7f06b7167270410def3ccfd076f) | `` automatic update `` |
| [`e5b7c9a8`](https://github.com/nix-community/NUR/commit/e5b7c9a8aee7ebebd5fb60718660ec469809606c) | `` automatic update `` |
| [`e6284d52`](https://github.com/nix-community/NUR/commit/e6284d52693e29663f741f5cd65c3e70934ed061) | `` automatic update `` |