### PR TITLE
chore(flake/chaotic): `766a5763` -> `fdcdc42e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755261355,
-        "narHash": "sha256-RQVhOuwfLSB64CMv8GMfBFZ2PXmIVleZeZskItqgD5o=",
+        "lastModified": 1755288426,
+        "narHash": "sha256-Ppsg77kOV4bstSOIw7xt7+pIODfbUH3ud3FNFOjm0xE=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "766a57635e5afd201c5d918087e5f9c9f63bfed1",
+        "rev": "fdcdc42efa880f79839734490f46a9f545ade4e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`fdcdc42e`](https://github.com/chaotic-cx/nyx/commit/fdcdc42efa880f79839734490f46a9f545ade4e1) | `` scx_git: d4dd7b1 -> dc7c785 (#1152) `` |
| [`118d6363`](https://github.com/chaotic-cx/nyx/commit/118d6363f19358148fd18ca3eb4a366327771393) | `` failures: update aarch64-darwin ``     |
| [`2d16b5a1`](https://github.com/chaotic-cx/nyx/commit/2d16b5a1f5222c8a9fec5238d85b5b2f77e32c6b) | `` failures: update aarch64-linux ``      |