### PR TITLE
chore(flake/nur): `861cbfb2` -> `4c2e66a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755276415,
-        "narHash": "sha256-y+OB105ElTRgPG8bJaRwiM0nCYAdV3JFyy5F/1uBUC4=",
+        "lastModified": 1755288894,
+        "narHash": "sha256-p/3EsZDAcZ53h7fH931xGJzDTSj78MZbA71pa+b5tD4=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "861cbfb2b7ea21769ad0cedc24674f7dd0301a6b",
+        "rev": "4c2e66a2d7430c73c5280672b7826b709e0dff02",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4c2e66a2`](https://github.com/nix-community/NUR/commit/4c2e66a2d7430c73c5280672b7826b709e0dff02) | `` automatic update `` |
| [`b6343f40`](https://github.com/nix-community/NUR/commit/b6343f40d743ce2532d45f5f11e0b705849f5328) | `` automatic update `` |
| [`cd892bd2`](https://github.com/nix-community/NUR/commit/cd892bd2c7e7c68fea06a839562109bdf8c6ab8d) | `` automatic update `` |
| [`e6d4f722`](https://github.com/nix-community/NUR/commit/e6d4f72242a95eaa05631bd3424e58e3b4902e4e) | `` automatic update `` |
| [`1be6f534`](https://github.com/nix-community/NUR/commit/1be6f53418526c0c4bd6a40075f7d2403e27707e) | `` automatic update `` |
| [`445e2a7a`](https://github.com/nix-community/NUR/commit/445e2a7a2892d98cd89bb67a49bdd5c235642e5f) | `` automatic update `` |
| [`7834b35b`](https://github.com/nix-community/NUR/commit/7834b35bc55568bd65e3cb9c8b11243b5fc66b80) | `` automatic update `` |