### PR TITLE
chore(flake/nix-gaming): `97bf2750` -> `ea98e1bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755223400,
-        "narHash": "sha256-iUAvYWdu91xO2xBmxXmAMymKvxxs1orbbUDhaubyp24=",
+        "lastModified": 1755339670,
+        "narHash": "sha256-KyCQsjXtv7zTnnh5O4sMe11m3b2bRVNlrcKLBPOwPQ0=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "97bf2750a74b02dbfc1131d99862c9ddd842a48d",
+        "rev": "ea98e1bf7948da86a3e8f69ddab46e10b5ea4079",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                     |
| --------------------------------------------------------------------------------------------------- | --------------------------- |
| [`ea98e1bf`](https://github.com/fufexan/nix-gaming/commit/ea98e1bf7948da86a3e8f69ddab46e10b5ea4079) | `` faf-client: fix build `` |
| [`b43d44ac`](https://github.com/fufexan/nix-gaming/commit/b43d44ac0eb181d36677b0652ff583c1e04658d5) | `` wine-mono: fix ``        |
| [`51ba579b`](https://github.com/fufexan/nix-gaming/commit/51ba579b0dc06f01af4fff6fd4eb63cebd7e4021) | `` Update packages ``       |