### PR TITLE
chore(flake/nixpkgs): `3385ca0c` -> `ad7196ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755078291,
-        "narHash": "sha256-Hu/gTDoi4uy6TAKISPHQusSMy8U6xUbLSDjKBYdhDIY=",
+        "lastModified": 1755274400,
+        "narHash": "sha256-rTInmnp/xYrfcMZyFMH3kc8oko5zYfxsowaLv1LVobY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3385ca0cd7e14c1a1eb80401fe011705ff012323",
+        "rev": "ad7196ae55c295f53a7d1ec39e4a06d922f3b899",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`7755995e`](https://github.com/NixOS/nixpkgs/commit/7755995e61878a8c233f3f57e307baab8ca6afca) | `` helix: 25.01.1 -> 25.07 ``                                                           |
| [`85891004`](https://github.com/NixOS/nixpkgs/commit/8589100487c7c61042443bf0c6e2dfab42413392) | `` litestream: fix CVE-2024-41254 by adding SSH host key verification ``                |
| [`1e83f79e`](https://github.com/NixOS/nixpkgs/commit/1e83f79ef0400fef7d47c9078f414f56e0f7db01) | `` brave: 1.81.131 -> 1.81.135 ``                                                       |
| [`09e89b60`](https://github.com/NixOS/nixpkgs/commit/09e89b60bbdc3d3d40f1f7649b63391fc5d6f3b8) | `` zenmap: add setuptools-gettext to build-system ``                                    |
| [`8de22e83`](https://github.com/NixOS/nixpkgs/commit/8de22e83436ffb1b733296e4300637611ef30f8b) | `` nmap: 7.97 -> 7.98 ``                                                                |
| [`5e0dafbe`](https://github.com/NixOS/nixpkgs/commit/5e0dafbe09bc1e635b797bd8400a162555cf6b03) | `` zipline: 4.2.1 -> 4.2.3 ``                                                           |
| [`775069d7`](https://github.com/NixOS/nixpkgs/commit/775069d70c80a047d2aa9ad0bb7cd0a84730d6ec) | `` zipline: prune node_modules ``                                                       |
| [`1449016e`](https://github.com/NixOS/nixpkgs/commit/1449016e14e708e4a3ca9656bd47baaaa3e44338) | `` draupnir: 2.6.0 -> 2.6.1 ``                                                          |
| [`85d48c64`](https://github.com/NixOS/nixpkgs/commit/85d48c644e322f105316d7ed23cc92b49a23ac05) | `` gitlab: 18.2.1 -> 18.2.2 ``                                                          |
| [`5dcee1dd`](https://github.com/NixOS/nixpkgs/commit/5dcee1dde895d8c598b365953245583d1720f608) | `` chhoto-url: 6.2.12 -> 6.2.13 ``                                                      |
| [`83a1d90b`](https://github.com/NixOS/nixpkgs/commit/83a1d90baf24a24416b561f4a14b4df5f8b6394b) | `` nginxMainline: 1.27.5 -> 1.29.1 ``                                                   |
| [`5b255259`](https://github.com/NixOS/nixpkgs/commit/5b255259e6b2fea398627c25191998daaa737e97) | `` postgresql: 13.21 -> 13.22 ``                                                        |
| [`e3a2ea6f`](https://github.com/NixOS/nixpkgs/commit/e3a2ea6fdbbe21e7a9a6b55faa75f343f2070eaf) | `` postgresql: 14.18 -> 14.19 ``                                                        |
| [`0ce01edb`](https://github.com/NixOS/nixpkgs/commit/0ce01edbdff75ae61fca7b1430c38372bc37d20d) | `` postgresql: 15.13 -> 15.14 ``                                                        |
| [`1dbf1377`](https://github.com/NixOS/nixpkgs/commit/1dbf1377d6fd27d18f1da096d2db5e5ccbc28233) | `` postgresql: 16.9 -> 16.10 ``                                                         |
| [`03b87371`](https://github.com/NixOS/nixpkgs/commit/03b87371dd0c3f5f2a74bcc3e2cb1348d57f96ee) | `` postgresql: 17.5 -> 17.6 ``                                                          |
| [`91798162`](https://github.com/NixOS/nixpkgs/commit/91798162b9910201adf46946aa49be2cca67acf8) | `` lmstudio: 0.3.22.1 -> 0.3.23.3 ``                                                    |
| [`4c7d5964`](https://github.com/NixOS/nixpkgs/commit/4c7d596449319fb46a995b64ce9c0a02e5207620) | `` protonmail-export: init at 1.0.5 ``                                                  |
| [`e28af20f`](https://github.com/NixOS/nixpkgs/commit/e28af20f2d5ed464d321b2f47a3f71032b5ff4f8) | `` emacs: 30.1 -> 30.2 ``                                                               |
| [`d62d8d54`](https://github.com/NixOS/nixpkgs/commit/d62d8d54fa3e6a0a26ff0642f91c0cad2d222330) | `` radicle-node: 1.2.1 → 1.3.0 ``                                                       |
| [`af1ea58a`](https://github.com/NixOS/nixpkgs/commit/af1ea58a87fdb4844c7e480cfbca772b92143b4f) | `` radicle-node: 1.2.0 → 1.2.1 ``                                                       |
| [`e0cf53a1`](https://github.com/NixOS/nixpkgs/commit/e0cf53a17bc69336236655d09058eb519c7e6000) | `` nextcloudPackages.tables: init at 0.9.5 ``                                           |
| [`bc09b678`](https://github.com/NixOS/nixpkgs/commit/bc09b678d2b8900bd1cc4f24e3948b555f6c7aab) | `` nextcloudPackages: update ``                                                         |
| [`02aa7953`](https://github.com/NixOS/nixpkgs/commit/02aa7953234ddad7090c660f888fc2eeb48c5938) | `` nginx: apply patch for CVE-2025-53859 ``                                             |
| [`103d7968`](https://github.com/NixOS/nixpkgs/commit/103d7968a9d3c09ccb9b01e2c6763e85212be596) | `` aide: 0.19.1 -> 0.19.2 ``                                                            |
| [`2cb9c64c`](https://github.com/NixOS/nixpkgs/commit/2cb9c64c62620b08e5febee9d81fa0f4d2df7d02) | `` aide: 0.19 -> 0.19.1 ``                                                              |
| [`7322af6d`](https://github.com/NixOS/nixpkgs/commit/7322af6d570080b5eee2bd8b846d6da35a52b275) | `` aide: remove with lib ``                                                             |
| [`86a8c895`](https://github.com/NixOS/nixpkgs/commit/86a8c89588a524b0d853b826d4984560103500c8) | `` agenix-cli: use finalAttrs pattern instead of rec ``                                 |
| [`f0751a59`](https://github.com/NixOS/nixpkgs/commit/f0751a59028416c4d1c425ed1a6640223e2931cb) | `` agenix-cli: 0.1.0 -> 0.1.2 ``                                                        |
| [`c696721a`](https://github.com/NixOS/nixpkgs/commit/c696721a56af27190c1d86b75a371ddf55c11eed) | `` agenix-cli: migrate rev to tag ``                                                    |
| [`e5b6a23d`](https://github.com/NixOS/nixpkgs/commit/e5b6a23dcf4befd710851fb3c4017fe5c16e6624) | `` yt-dlp: 2025.07.21 -> 2025.08.11 ``                                                  |
| [`654a1c86`](https://github.com/NixOS/nixpkgs/commit/654a1c86cdb6d21b95645960ba13f54198e6e50c) | `` ci/github-script/commits: conditionally show comments ``                             |
| [`0d3ebd9f`](https://github.com/NixOS/nixpkgs/commit/0d3ebd9fae897cbd47aa83584e588eccf94c2ea0) | `` ci/github-script/commits: clarify comments ``                                        |
| [`f0dedca9`](https://github.com/NixOS/nixpkgs/commit/f0dedca9348e22371753bb673a6a873cb2209f4d) | `` ci/github-script/commits: allow reason for not cherry-picking ``                     |
| [`ac4dc6c2`](https://github.com/NixOS/nixpkgs/commit/ac4dc6c24bc69867af91ab1925dc5f6bdd104773) | `` shipwright: nixfmt-rfc-style ``                                                      |
| [`523ed159`](https://github.com/NixOS/nixpkgs/commit/523ed1596f80f403900ec5137eea647a681a46d7) | `` shipwright: 9.0.2 -> 9.0.5 ``                                                        |
| [`00aa298f`](https://github.com/NixOS/nixpkgs/commit/00aa298fa0659b4db8af11d664a1d10c029a8453) | `` home-assistant-custom-components.octopus_energy: init at 16.0.2 ``                   |
| [`ad0d79ea`](https://github.com/NixOS/nixpkgs/commit/ad0d79ea4fbbe2bafc370874bc888d29c320bdf3) | `` perlPackages.CatalystAuthenticationCredentialHTTP: apply patch for CVE-2025-40920 `` |
| [`a1c22119`](https://github.com/NixOS/nixpkgs/commit/a1c2211951dfaf31fc06f2c96d0730c758b70b82) | `` perlPackages.CryptSysRandom: init at 0.007 ``                                        |
| [`c4900d54`](https://github.com/NixOS/nixpkgs/commit/c4900d54b6f6c5d64f0c54608866b37cafa96a81) | `` r2modman: 3.2.1 -> 3.2.3 ``                                                          |
| [`dfba09a9`](https://github.com/NixOS/nixpkgs/commit/dfba09a98b9e7e4973d6caa4713f7b820a207e33) | `` r2modman: 3.2.0 -> 3.2.1 ``                                                          |
| [`63ea3b08`](https://github.com/NixOS/nixpkgs/commit/63ea3b08b493fee69aa70f0e8cd2bc40399d3236) | `` r2modman: handle ror2mm:// links (#410692) ``                                        |
| [`e5e1b0e9`](https://github.com/NixOS/nixpkgs/commit/e5e1b0e945cef73929868654998bd441fdaa146c) | `` r2modman: 3.1.58 -> 3.2.0 ``                                                         |
| [`71509b20`](https://github.com/NixOS/nixpkgs/commit/71509b203f2eb847953eaa8b74e27a289ca1497b) | `` matrix-alertmanager: 0.8.0 -> 0.9.0 ``                                               |
| [`6cbd1892`](https://github.com/NixOS/nixpkgs/commit/6cbd18920030c8afd6c41f7855284507fd785708) | `` picocrypt: 1.48 -> 1.49 ``                                                           |
| [`dbe8dd59`](https://github.com/NixOS/nixpkgs/commit/dbe8dd59e21c3a789e044cd1136cfdde976adb51) | `` tomcat10: 10.1.43 -> 10.1.44 ``                                                      |
| [`2dae4e51`](https://github.com/NixOS/nixpkgs/commit/2dae4e519d36711e4f23d5f26227afde7f27e9f6) | `` tomcat: 11.0.9 -> 11.0.10 ``                                                         |
| [`1a98b7d6`](https://github.com/NixOS/nixpkgs/commit/1a98b7d6ac1ca53c7680e8a55dbb424585f0b216) | `` tomcat9: 9.0.107 -> 9.0.108 ``                                                       |
| [`f5648130`](https://github.com/NixOS/nixpkgs/commit/f5648130bb84b0142f5b5bd6e2caa863259e6bbc) | `` linuxPackages.prl-tools: 20.4.0-55980 -> 20.4.1-55996 ``                             |
| [`544e965a`](https://github.com/NixOS/nixpkgs/commit/544e965ac81c8c37eb251aee8996d78fc711dc1e) | `` tutanota-desktop: 277.250414.1 -> 299.250725.1 ``                                    |
| [`8966cc11`](https://github.com/NixOS/nixpkgs/commit/8966cc11dcac16767eca0c1dd5301f02be46e77f) | `` vimPlugins.themery-nvim: init at 2025-01-01 ``                                       |
| [`d56b67d2`](https://github.com/NixOS/nixpkgs/commit/d56b67d2c1c51736cb792396c6be90b90baa77c9) | `` beets: refresh failing tests list ``                                                 |
| [`fe1404b8`](https://github.com/NixOS/nixpkgs/commit/fe1404b8030cec1dc55eafd1d23dda304bfefa68) | `` workflows/merge-group: init ``                                                       |
| [`36c6cb85`](https://github.com/NixOS/nixpkgs/commit/36c6cb850b23cd1bb86d547554c0a385e7517399) | `` python313Packages.img2pdf: skip tests that fail on aarch64 ``                        |
| [`ba4ea5ec`](https://github.com/NixOS/nixpkgs/commit/ba4ea5ec8dc427dc9348932036e1b9da8e1c940c) | `` cargo-semver-checks: skip platform specific tests ``                                 |
| [`c5e81475`](https://github.com/NixOS/nixpkgs/commit/c5e8147551ce1332e69620264f06583a5353908e) | `` proton-ge-bin: GE-Proton10-11 -> GE-Proton10-12 ``                                   |
| [`000f2b04`](https://github.com/NixOS/nixpkgs/commit/000f2b045472646b58a38779f8d9fa01638b7448) | `` mprisence: init at 1.2.4 ``                                                          |
| [`da36114a`](https://github.com/NixOS/nixpkgs/commit/da36114ad4890de1593747a7b64e9c993da8c9e5) | `` amazon-q-cli: 1.12.7 -> 1.13.1 ``                                                    |
| [`dfba93cb`](https://github.com/NixOS/nixpkgs/commit/dfba93cbf92ae10f55f22dc538331f554c24d0f6) | `` amazon-q-cli: 1.12.6 -> 1.12.7 ``                                                    |
| [`fec11171`](https://github.com/NixOS/nixpkgs/commit/fec11171288b6cd50b8f36aae202db73aca5b821) | `` amazon-q-cli: 1.12.4 -> 1.12.6 ``                                                    |
| [`5742d4c6`](https://github.com/NixOS/nixpkgs/commit/5742d4c6f3901589b5bbd8c06360410634cb5868) | `` amazon-q-cli: 1.12.2 -> 1.12.4 ``                                                    |
| [`a3033a9a`](https://github.com/NixOS/nixpkgs/commit/a3033a9adee9ad9a2ffa89d600151d13ea81be53) | `` amazon-q-cli: 1.12.1 -> 1.12.2 ``                                                    |
| [`d8764b49`](https://github.com/NixOS/nixpkgs/commit/d8764b49815b00dbd480c323c3d3994f6572f1dc) | `` amazon-q-cli: add darwin to supported platforms ``                                   |
| [`85ecd6a3`](https://github.com/NixOS/nixpkgs/commit/85ecd6a3c086cbc03cdec6dd93d6076d35ab3e7b) | `` fluent-bit: 4.0.5 -> 4.0.7 ``                                                        |
| [`1a0b5dda`](https://github.com/NixOS/nixpkgs/commit/1a0b5ddacde7d045c980d926ea6db39b60d23734) | `` ungoogled-chromium: 139.0.7258.66-1 -> 139.0.7258.127-1 ``                           |
| [`371e6f58`](https://github.com/NixOS/nixpkgs/commit/371e6f58c1ba83c5c94796be0fd7e80ef8b3b435) | `` nixVersions.nix_2_30: 2.30.1 -> 2.30.2 ``                                            |
| [`b6c2a305`](https://github.com/NixOS/nixpkgs/commit/b6c2a3059d23971a144dd76a6a63382d7963291c) | `` nixVersions.nix_2_30: init at 2.30.1 ``                                              |
| [`01ccba37`](https://github.com/NixOS/nixpkgs/commit/01ccba375831890f45284d4cf70cd6eceeed6f11) | `` fluent-bit: 4.0.3 -> 4.0.5 ``                                                        |
| [`72561e59`](https://github.com/NixOS/nixpkgs/commit/72561e59685690441d8e5540303ae7483dc09679) | `` tuba: 0.10.0 -> 0.10.1 ``                                                            |
| [`a8e52c87`](https://github.com/NixOS/nixpkgs/commit/a8e52c87b2048bde76a5d33ee82f75ec4a05a7c4) | `` komikku: 1.84.0 -> 1.85.0 ``                                                         |
| [`3ef8956f`](https://github.com/NixOS/nixpkgs/commit/3ef8956f7401c96b02a0c1393b1cb23fc20faf29) | `` workflows/check: use regular checkout ``                                             |
| [`8f17aaaa`](https://github.com/NixOS/nixpkgs/commit/8f17aaaa8c7683ef5e578a44d60eb099fef31e23) | `` consul: 1.21.3 -> 1.21.4 ``                                                          |
| [`ff961587`](https://github.com/NixOS/nixpkgs/commit/ff961587b954396d3ebb13e8abf0d419fb2d5275) | `` vencord: 1.12.9 -> 1.12.10 ``                                                        |
| [`b02ced33`](https://github.com/NixOS/nixpkgs/commit/b02ced336f996fba1f80f82d98f37a19c4edc12b) | `` raycast: 1.102.3 -> 1.102.4 ``                                                       |
| [`2c362965`](https://github.com/NixOS/nixpkgs/commit/2c362965dbf29b190198fb17b81ed88f32ac528f) | `` librewolf-bin-unwrapped: 141.0-1 -> 141.0.3-1 ``                                     |
| [`4e534b5a`](https://github.com/NixOS/nixpkgs/commit/4e534b5a24e5f6044487fd5b408976e62cdbee02) | `` rmfakecloud: 0.0.24 -> 0.0.25 ``                                                     |
| [`ba142955`](https://github.com/NixOS/nixpkgs/commit/ba1429553adc1f0bdd089ed1f2ac5aa22d2e4ab1) | `` dropbear: disable wtmp when using musl ``                                            |
| [`89e909ea`](https://github.com/NixOS/nixpkgs/commit/89e909ea816ee24290610bb5140e3e49fcf8a510) | `` dolibarr: 21.0.2 -> 22.0.0 ``                                                        |
| [`349ad65f`](https://github.com/NixOS/nixpkgs/commit/349ad65f21821a229708e3295ea36a806e1e2e5b) | `` ocamlPackages.letters: init at 0.4.0 ``                                              |
| [`2aaa0ec0`](https://github.com/NixOS/nixpkgs/commit/2aaa0ec0874cbce9d2096cb69d70aeae9e9fe48f) | `` ocamlPackages.sendmail: init at 0.12.0 ``                                            |
| [`7eccfd5b`](https://github.com/NixOS/nixpkgs/commit/7eccfd5b5b9e9e0ae96cf5b85e04174d84d1c9d7) | `` ocamlPackages.colombe: init at 0.12.0 ``                                             |
| [`13100b88`](https://github.com/NixOS/nixpkgs/commit/13100b889d72db4187b7ca538807560c3c31939e) | `` opensnitch: 1.7.1 -> 1.7.2 ``                                                        |
| [`c16aec21`](https://github.com/NixOS/nixpkgs/commit/c16aec21b142f6bf51b338f9a2859e1f511ac61c) | `` chromium,chromedriver: 139.0.7258.66 -> 139.0.7258.127 ``                            |
| [`940d6132`](https://github.com/NixOS/nixpkgs/commit/940d6132e6d2453a04e308800c8c6aeb7356d61b) | `` modsecurity_standalone: 2.9.8 -> 2.9.12 ``                                           |
| [`952c02a1`](https://github.com/NixOS/nixpkgs/commit/952c02a1671dc18d1c66f08c87e073afb0cf8f24) | `` hydra: 0-unstable-2025-08-05 -> 0-unstable-2025-08-12 ``                             |
| [`d711b96f`](https://github.com/NixOS/nixpkgs/commit/d711b96f3ab85111ced2fc85bc72d8cc3d6508c0) | `` microcode-intel: 20250512 -> 20250812 ``                                             |
| [`588e6e3a`](https://github.com/NixOS/nixpkgs/commit/588e6e3a01d08d48bd7ec62d3bce17dd0aae0cd6) | `` microcode-intel: use finalAttrs ``                                                   |
| [`bea0e02f`](https://github.com/NixOS/nixpkgs/commit/bea0e02fc85107f3e9d8dc6f2613d8470dc28697) | `` openxr-loader: 1.1.49 -> 1.1.50 ``                                                   |
| [`9a9268fb`](https://github.com/NixOS/nixpkgs/commit/9a9268fb21f93593db3765d38ed1aa345b186fcd) | `` openxr-loader: 1.1.47 -> 1.1.49 ``                                                   |
| [`44aa31dc`](https://github.com/NixOS/nixpkgs/commit/44aa31dc464f880a1751f99e8a0b55697bb99e0d) | `` github-runner: skip another alpine container test on aarch64-linux ``                |
| [`5c7f2697`](https://github.com/NixOS/nixpkgs/commit/5c7f26977d3fd0909f5e32b04fb661458caca958) | `` flyctl: 0.3.164 -> 0.3.169 ``                                                        |
| [`bb46e511`](https://github.com/NixOS/nixpkgs/commit/bb46e511fdd45097ebcd0c0b2a1acc0aa5fbb211) | `` nheko: 0.12.0 -> 0.12.1 ``                                                           |
| [`9f208645`](https://github.com/NixOS/nixpkgs/commit/9f20864511cea81761a7057f3a89475033ee99fa) | `` mtxclient: 0.10.0 -> 0.10.1 ``                                                       |
| [`bef1d61d`](https://github.com/NixOS/nixpkgs/commit/bef1d61d35ff5eb9a969b16379b4e42141c1453d) | `` element-desktop: fix sandbox build on darwin ``                                      |
| [`587d7288`](https://github.com/NixOS/nixpkgs/commit/587d72880ab28d2c5ee8b8f5c5bd52661e868626) | `` nixos/slurm: remove mysql/InnoDB tuning settings, unbreak test ``                    |
| [`c07cf133`](https://github.com/NixOS/nixpkgs/commit/c07cf133022452f2f5aeba8d95da0a60833c8188) | `` pdns-recursor: 5.2.2 -> 5.2.5 ``                                                     |
| [`e5546cbb`](https://github.com/NixOS/nixpkgs/commit/e5546cbb53d8c8efea833185b54775eb77f014a7) | `` _7zz: 25.00 -> 25.01 ``                                                              |
| [`6ab8cc1d`](https://github.com/NixOS/nixpkgs/commit/6ab8cc1d2991729a70bd7048de737729e85d1b58) | `` velocity: 3.4.0-unstable-2025-06-11 -> 3.4.0-unstable-2025-08-02 ``                  |
| [`4aa2c4aa`](https://github.com/NixOS/nixpkgs/commit/4aa2c4aaaefdd8ecfbbb5aa2300961965114f52c) | `` nixos/tests/velocity: fix mcstatus command ``                                        |
| [`5c22e503`](https://github.com/NixOS/nixpkgs/commit/5c22e503e6591d3208424c356265e2cb663ca6b6) | `` velocity: 3.4.0-unstable-2025-05-21 -> 3.4.0-unstable-2025-06-11 ``                  |
| [`b8e6c987`](https://github.com/NixOS/nixpkgs/commit/b8e6c98725970afad6eae93fe7b615c02c69e1a5) | `` velocity: 3.4.0-unstable-2025-05-09 -> 3.4.0-unstable-2025-05-21 ``                  |
| [`2768ae1e`](https://github.com/NixOS/nixpkgs/commit/2768ae1e8b0bfd620cd541ee48076f7cdc82607f) | `` lmstudio: 0.3.20.4 -> 0.3.22.1 ``                                                    |
| [`3fba9c83`](https://github.com/NixOS/nixpkgs/commit/3fba9c8328ce50d1c79ed14416c41542f411d457) | `` lmstudio: 0.3.18-3 -> 0.3.20-4 ``                                                    |
| [`80f3bfef`](https://github.com/NixOS/nixpkgs/commit/80f3bfeffed8d7f03adc0d72ce7922349d66c197) | `` neovim[-unwrapped]: 0.11.2 -> 0.11.3 ``                                              |
| [`899bab07`](https://github.com/NixOS/nixpkgs/commit/899bab07647e8168fe71c0e333d829a82725bd92) | `` python3Packages.ansible: 11.7.0 -> 11.8.0 ``                                         |
| [`a507f138`](https://github.com/NixOS/nixpkgs/commit/a507f138e0c1af617dab1a34a9262e5175bb1da1) | `` ansible: add maintainer robsliwi ``                                                  |
| [`f19d268b`](https://github.com/NixOS/nixpkgs/commit/f19d268be0d9786f8dfe14757a749a85c57ef6e9) | `` ansible: add maintainer HarisDotParis ``                                             |
| [`49249d4d`](https://github.com/NixOS/nixpkgs/commit/49249d4dc37dfc2b6ec9dbd5b1990c211966f275) | `` python3Packages.ansible: 11.5.0 -> 11.7.0 ``                                         |
| [`83df04eb`](https://github.com/NixOS/nixpkgs/commit/83df04eb5e2338bffd2fe26c3816e45e0f98a610) | `` python3Packages.ansible: 11.4.0 -> 11.5.0 ``                                         |
| [`4714abbe`](https://github.com/NixOS/nixpkgs/commit/4714abbe1673e005438b67a076577d45077d7b67) | `` nixos/freshrss: fix loading extensions' static content ``                            |
| [`1c6aede8`](https://github.com/NixOS/nixpkgs/commit/1c6aede85dec16d1e4a66dc3c9ffbf354f75e11b) | `` nixosTests.freshrss: handleTest -> runTest ``                                        |
| [`7ef28f65`](https://github.com/NixOS/nixpkgs/commit/7ef28f65321e91620e04b4ae05ec9b09ec8a4cab) | `` emscripten: 4.0.8 -> 4.0.10 ``                                                       |
| [`307f9021`](https://github.com/NixOS/nixpkgs/commit/307f902122c0d6fd9a843db8916c78e6ee14714c) | `` ludusavi: use finalAttrs ``                                                          |
| [`bbc6e664`](https://github.com/NixOS/nixpkgs/commit/bbc6e664f8e25ef5c09ad3339ec486e5a5bad328) | `` caido: 0.50.0 -> 0.50.1 ``                                                           |
| [`d5ff5667`](https://github.com/NixOS/nixpkgs/commit/d5ff56670315777785cd31a78038dc4b89efc725) | `` caido: 0.49.0 -> 0.50.0 ``                                                           |
| [`145344df`](https://github.com/NixOS/nixpkgs/commit/145344dfe80c8bdc3d9252ebfbc9c65957ccfbec) | `` caido: 0.48.1 -> 0.49.0 ``                                                           |
| [`fb9fe172`](https://github.com/NixOS/nixpkgs/commit/fb9fe17242d6a244f806af63e3f6aa2d746a7e41) | `` caido: 0.48.0 -> 0.48.1 ``                                                           |
| [`fa4cbb58`](https://github.com/NixOS/nixpkgs/commit/fa4cbb585b9d117b322945ec9f2d664bbea0ccea) | `` changie: 1.22.0 -> 1.22.1 ``                                                         |
| [`0404b2ae`](https://github.com/NixOS/nixpkgs/commit/0404b2aee1b92999739f46ef9e26df519ac85c08) | `` changie: 1.21.1 -> 1.22.0 ``                                                         |
| [`cadce4b0`](https://github.com/NixOS/nixpkgs/commit/cadce4b023a43102ae947999677c7ab3a7091d99) | `` juju: 3.6.7 -> 3.6.8 ``                                                              |
| [`fd93dc16`](https://github.com/NixOS/nixpkgs/commit/fd93dc16abd63afaddc16f68303ef594e91ba93c) | `` juju: 3.6.6 -> 3.6.7 ``                                                              |
| [`a210954f`](https://github.com/NixOS/nixpkgs/commit/a210954f5b04eccaab9913ee7ce18879be4ec5d8) | `` juju: 3.6.5 -> 3.6.6 ``                                                              |
| [`1f49cb2a`](https://github.com/NixOS/nixpkgs/commit/1f49cb2a08453a20b804639d28952882e20dcf2e) | `` slimevr: 0.15.0 -> 0.16.0 ``                                                         |
| [`17a789f0`](https://github.com/NixOS/nixpkgs/commit/17a789f0473e922646724ef15855386838ea6870) | `` saga: 9.9.0 -> 9.9.1 ``                                                              |
| [`b4a449fd`](https://github.com/NixOS/nixpkgs/commit/b4a449fda1889a00aa2f4514dc4a8a32cddd5b70) | `` saga: 9.8.1 -> 9.9.0 ``                                                              |
| [`adeef382`](https://github.com/NixOS/nixpkgs/commit/adeef382519393187489e8858ce8bf115c28a971) | `` saga: 9.7.2 → 9.8.1 ``                                                               |
| [`bb2640a8`](https://github.com/NixOS/nixpkgs/commit/bb2640a85b0bd80298532cd9447e52d6779d1723) | `` openvpn3: 24.1 -> 25 ``                                                              |
| [`eed92393`](https://github.com/NixOS/nixpkgs/commit/eed9239332f35b299f99729dd287f377f1f17b42) | `` openvpn3: add `passthru.updateScript` ``                                             |
| [`4ad7afbc`](https://github.com/NixOS/nixpkgs/commit/4ad7afbc8434c0f75468608ba62f880b844bd7e1) | `` imagemagick: 7.1.1-47 -> 7.1.2-0 ``                                                  |
| [`782e7931`](https://github.com/NixOS/nixpkgs/commit/782e7931963a42fbcca2b9e7f0b73e9bdfdf41c1) | `` wxGTK32: 3.2.7.1 -> 3.2.8.1 ``                                                       |