### PR TITLE
chore(flake/nur): `5827ed08` -> `4595b515`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755353643,
-        "narHash": "sha256-hXX4TW85qnK3rRoFJOSTf0NVUn8wv2D9Pmf2A4rPG9g=",
+        "lastModified": 1755370318,
+        "narHash": "sha256-AQM1BzVrtNsOBNYvEfdbt5YCy2qmCl/AeBmQK2UYwvI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "5827ed08e8024ecd5d280087e9cfb6b1d8645470",
+        "rev": "4595b51518052f4cae78a67ce4c20a4a4a83a3a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4595b515`](https://github.com/nix-community/NUR/commit/4595b51518052f4cae78a67ce4c20a4a4a83a3a5) | `` automatic update `` |
| [`9e89e96c`](https://github.com/nix-community/NUR/commit/9e89e96c58f3cd64fb705d7d0703796806efb454) | `` automatic update `` |
| [`a6d4c447`](https://github.com/nix-community/NUR/commit/a6d4c4476f59a45839f71b7aacc2e2132bb16bbe) | `` automatic update `` |
| [`68c3ae81`](https://github.com/nix-community/NUR/commit/68c3ae81dc38e37820c4a639b95fd88f00710008) | `` automatic update `` |