### PR TITLE
chore(flake/nur): `4595b515` -> `c98d1d13`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755370318,
-        "narHash": "sha256-AQM1BzVrtNsOBNYvEfdbt5YCy2qmCl/AeBmQK2UYwvI=",
+        "lastModified": 1755377195,
+        "narHash": "sha256-HdvFtKx6OZdSr0UUD10jV79CU+wjSJQf/77yExWRqXI=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "4595b51518052f4cae78a67ce4c20a4a4a83a3a5",
+        "rev": "c98d1d13a1a22fdbe67a1a7b2a8e1632e898fb0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c98d1d13`](https://github.com/nix-community/NUR/commit/c98d1d13a1a22fdbe67a1a7b2a8e1632e898fb0e) | `` automatic update `` |
| [`ec328b0e`](https://github.com/nix-community/NUR/commit/ec328b0ec6558e01dabd94b304c4363a405b264b) | `` automatic update `` |
| [`e52b1820`](https://github.com/nix-community/NUR/commit/e52b18205d9b7e7920f8583c7eb6fdb0493fcfa8) | `` automatic update `` |
| [`a8625e43`](https://github.com/nix-community/NUR/commit/a8625e43058f543537ef28f88e92e408e7bf6b80) | `` automatic update `` |