### PR TITLE
chore(flake/nur): `c98d1d13` -> `c9ebe16b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755377195,
-        "narHash": "sha256-HdvFtKx6OZdSr0UUD10jV79CU+wjSJQf/77yExWRqXI=",
+        "lastModified": 1755402326,
+        "narHash": "sha256-Jqgo3+DmR5s4P4OmMdp5GQLKLz1TWYLOX511iIfkPec=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c98d1d13a1a22fdbe67a1a7b2a8e1632e898fb0e",
+        "rev": "c9ebe16bc316aa4efe7db097d32e38269d1c8f7a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c9ebe16b`](https://github.com/nix-community/NUR/commit/c9ebe16bc316aa4efe7db097d32e38269d1c8f7a) | `` automatic update `` |
| [`7e0b9686`](https://github.com/nix-community/NUR/commit/7e0b9686cfa51eda0c2f3f4777b61f628f230586) | `` automatic update `` |
| [`bef2b008`](https://github.com/nix-community/NUR/commit/bef2b008f7aa305d2f4af9a1e579f55b3497be33) | `` automatic update `` |
| [`5d7b845c`](https://github.com/nix-community/NUR/commit/5d7b845c2199ca94d52f65e1f54ef91e910c2dc1) | `` automatic update `` |
| [`288b1732`](https://github.com/nix-community/NUR/commit/288b17321085d6d08d5d11b37d2eb778f0910530) | `` automatic update `` |
| [`13978a2f`](https://github.com/nix-community/NUR/commit/13978a2fffadb5d62b8bc5f07adb14cc10a40d8b) | `` automatic update `` |
| [`9705c629`](https://github.com/nix-community/NUR/commit/9705c62979bca61d5205bb0a6581dfd6810eb973) | `` automatic update `` |
| [`e5c56df5`](https://github.com/nix-community/NUR/commit/e5c56df534cd78204af1265210616ce903e5f458) | `` automatic update `` |