### PR TITLE
chore(flake/nur): `c9ebe16b` -> `dab12a4c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755402326,
-        "narHash": "sha256-Jqgo3+DmR5s4P4OmMdp5GQLKLz1TWYLOX511iIfkPec=",
+        "lastModified": 1755409702,
+        "narHash": "sha256-lyq1vDIFBpQxM/rMUWAGqSNeVUMbu7L78VP35Em0n0c=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "c9ebe16bc316aa4efe7db097d32e38269d1c8f7a",
+        "rev": "dab12a4cbba10f00d9cd6310f3796ba951ec2084",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`dab12a4c`](https://github.com/nix-community/NUR/commit/dab12a4cbba10f00d9cd6310f3796ba951ec2084) | `` automatic update `` |
| [`70dd987d`](https://github.com/nix-community/NUR/commit/70dd987dcfdaa9fb6274dc348ead40748e10ee1b) | `` automatic update `` |
| [`5fe8f406`](https://github.com/nix-community/NUR/commit/5fe8f40618b14bf31ab6f05d1822d0ce6d354906) | `` automatic update `` |
| [`ca081f34`](https://github.com/nix-community/NUR/commit/ca081f34215acc159d309eb8420690989377486c) | `` automatic update `` |
| [`4c6e7f89`](https://github.com/nix-community/NUR/commit/4c6e7f89dc178869d84bd987ad7a4a6e5332d39c) | `` automatic update `` |
| [`3d6a3ec4`](https://github.com/nix-community/NUR/commit/3d6a3ec4742479d9538ae992f0f4db02738ab537) | `` automatic update `` |
| [`ade77871`](https://github.com/nix-community/NUR/commit/ade77871bd255132054d9d0be6acdf90104a7789) | `` automatic update `` |