### PR TITLE
chore(flake/nur): `dab12a4c` -> `544bd042`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755409702,
-        "narHash": "sha256-lyq1vDIFBpQxM/rMUWAGqSNeVUMbu7L78VP35Em0n0c=",
+        "lastModified": 1755423035,
+        "narHash": "sha256-oqWm9uPNiBJgO/LfJK7xKKbfSySBq5nwn/WOaXTPimM=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "dab12a4cbba10f00d9cd6310f3796ba951ec2084",
+        "rev": "544bd04284061e2f14c6a2f9cb4e22f67ed91727",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`544bd042`](https://github.com/nix-community/NUR/commit/544bd04284061e2f14c6a2f9cb4e22f67ed91727) | `` automatic update `` |
| [`d0ab55a3`](https://github.com/nix-community/NUR/commit/d0ab55a3d643383718819f406e83fd8093d55786) | `` automatic update `` |
| [`6bd388b8`](https://github.com/nix-community/NUR/commit/6bd388b8785ba17e88311ca4b1f28efb9c296bda) | `` automatic update `` |