### PR TITLE
chore(flake/chaotic): `038dc9d8` -> `018c0eea`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,11 +27,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1755392722,
-        "narHash": "sha256-Sh7oT5FugUMI91sP1G35v7QuMmTwj+KjEITbn0AI/Ho=",
+        "lastModified": 1755416648,
+        "narHash": "sha256-fOCzR+Ymt7K0N3wExttJAR+cMEWFpda3FscV5gL6DUo=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "038dc9d81f76e4f9f59c81fb021ceb6979a248fa",
+        "rev": "018c0eeafe5eb58ed2164f2628d6843b28053a64",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                       |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`018c0eea`](https://github.com/chaotic-cx/nyx/commit/018c0eeafe5eb58ed2164f2628d6843b28053a64) | `` linux_cachyos: 6.16.0 -> 6.16.1 (#1154) `` |
| [`4ff91c7b`](https://github.com/chaotic-cx/nyx/commit/4ff91c7b0e15e66d4e648e6cf398fe7e528dbe0a) | `` failures: update aarch64-darwin ``         |
| [`ff1c3ac2`](https://github.com/chaotic-cx/nyx/commit/ff1c3ac2ad4236579875ca64871b41f479458616) | `` failures: update aarch64-linux ``          |