### PR TITLE
chore(flake/nur): `ffaa7d51` -> `8509a135`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755436015,
-        "narHash": "sha256-Y0o6py+h0+5CtWs/fJQOLaIMwCsOjDBZ5SeaE1VJ5N8=",
+        "lastModified": 1755441713,
+        "narHash": "sha256-bxN6mZti2vbHl4NUYLDaYdqULNay1qbkxUeVAN6DE+8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "ffaa7d5185910bfaeda1cfed7ad441809f7d890a",
+        "rev": "8509a13591f79f1772501d1d30c48f921c2aed3e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8509a135`](https://github.com/nix-community/NUR/commit/8509a13591f79f1772501d1d30c48f921c2aed3e) | `` automatic update `` |
| [`3cf97a4e`](https://github.com/nix-community/NUR/commit/3cf97a4e2861712a9b36386a78e14d63ff9bc4e4) | `` automatic update `` |
| [`a99607be`](https://github.com/nix-community/NUR/commit/a99607beba79103eb973f4fe2b4f38f603ec7ad4) | `` automatic update `` |