### PR TITLE
chore(flake/nur): `a2d07611` -> `b12cf912`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755456814,
-        "narHash": "sha256-JsyGp8vG2O4IAo/PDbmiSOENtAvtxyVyGB/qcWhrtQY=",
+        "lastModified": 1755463657,
+        "narHash": "sha256-zlwwq8sVyIs/i3unqtQEqRXFVIxaFzxtjGEAnNQjUsc=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "a2d0761105af3e9725db7522960ed7990a9b3762",
+        "rev": "b12cf912ef3f7d899cb78f3865c6f22befaca3ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b12cf912`](https://github.com/nix-community/NUR/commit/b12cf912ef3f7d899cb78f3865c6f22befaca3ad) | `` automatic update `` |
| [`03b70968`](https://github.com/nix-community/NUR/commit/03b709685c3b7f78a1964453ebf143287b03a01f) | `` automatic update `` |
| [`51a6445e`](https://github.com/nix-community/NUR/commit/51a6445eb7fbd8cbbc39218db0f2b7311b529eb6) | `` automatic update `` |
| [`608d257a`](https://github.com/nix-community/NUR/commit/608d257aad91634d980ae9bb2a58d0bcebe1b0a3) | `` automatic update `` |