### PR TITLE
chore(flake/nix-gaming): `2e90e677` -> `a97963a3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -232,11 +232,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1755568603,
-        "narHash": "sha256-FNOuvwyJcBOqiLxOz4rLdNFRP6Dmb0Glj1B3eEmkqj4=",
+        "lastModified": 1755593834,
+        "narHash": "sha256-lFFnBp3rDST1TCyQt/8qLWP9DRKiaxK4m8SqMIUWXS4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "2e90e67780909df264d79250ee72c96ac665ba33",
+        "rev": "a97963a3ce85ce065ae889452e8371024c4bb2f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                       |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`a97963a3`](https://github.com/fufexan/nix-gaming/commit/a97963a3ce85ce065ae889452e8371024c4bb2f6) | `` npins: fix fetchzip ``                     |
| [`66bca077`](https://github.com/fufexan/nix-gaming/commit/66bca077ca3edfdf7f3a87b5c5064cf138acfb77) | `` Revert "faf-client: fix build" ``          |
| [`132e24a9`](https://github.com/fufexan/nix-gaming/commit/132e24a9abdcd0beeffda529a0bd6018d61ea80e) | `` wineprefix-preparer: install ddraw ``      |
| [`430b8e5f`](https://github.com/fufexan/nix-gaming/commit/430b8e5f315dc930a54cb58bafe75930ebceec99) | `` cnc-ddraw: init at 7.1.0.0 ``              |
| [`5757b0e8`](https://github.com/fufexan/nix-gaming/commit/5757b0e8471c2860150cd94e5bdfa54b1657ee5a) | `` osu-lazer-bin: change desktop file name `` |
| [`9da3fa13`](https://github.com/fufexan/nix-gaming/commit/9da3fa13230c30d8696fae9d0c481deb471444e8) | `` osu-lazer-bin: use 44100 sample rate ``    |