### PR TITLE
chore(flake/nur): `bf9b3a8d` -> `d39e13e7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755595965,
-        "narHash": "sha256-EBXB+Up0CL+Twt6gHyrk1x7p3g8AZ6vUExFzJor9D8Y=",
+        "lastModified": 1755608947,
+        "narHash": "sha256-CqIwxS52S4sCas2EXY3Y6bM07o+tsjg2+hiFyB/0Utk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "bf9b3a8dd0bb5d78e440cd5b4f0646b581abce79",
+        "rev": "d39e13e798dc26f65256c7738a2a501845d21f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d39e13e7`](https://github.com/nix-community/NUR/commit/d39e13e798dc26f65256c7738a2a501845d21f4d) | `` automatic update `` |
| [`e92965e6`](https://github.com/nix-community/NUR/commit/e92965e6bad1a44445803a8567400e5c6ad9cbe6) | `` automatic update `` |