### PR TITLE
chore(flake/nixpkgs): `48f4c982` -> `a58390ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -461,11 +461,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1755471983,
-        "narHash": "sha256-axUoWcm4cNQ36jOlnkD9D40LTfSQgk8ExfHSRm3rTtg=",
+        "lastModified": 1755593991,
+        "narHash": "sha256-BA9MuPjBDx/WnpTJ0EGhStyfE7hug8g85Y3Ju9oTsM4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48f4c982de68d966421d2b6f1ddbeb6227cc5ceb",
+        "rev": "a58390ab6f1aa810eb8e0f0fc74230e7cc06de03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
| [`93e17511`](https://github.com/NixOS/nixpkgs/commit/93e1751170c18088bd8bc97432b4d6edeb03b496) | `` pkgsCross.aarch64-darwin.discord-canary: 0.0.836 -> 0.0.844 ``                                                                          |
| [`c51d301e`](https://github.com/NixOS/nixpkgs/commit/c51d301e69941a0cf89c1dffbf2a12ca18d4bb7b) | `` pkgsCross.aarch64-darwin.discord-ptb: 0.0.184 -> 0.0.186 ``                                                                             |
| [`cd197804`](https://github.com/NixOS/nixpkgs/commit/cd1978046d44d577cd83511d4ec87c9a8d3edff5) | `` pkgsCross.aarch64-darwin.discord: 0.0.355 -> 0.0.356 ``                                                                                 |
| [`1c7ae43f`](https://github.com/NixOS/nixpkgs/commit/1c7ae43fe10d1ba8343424e4d431f99d47353206) | `` discord-canary: 0.0.730 -> 0.0.740 ``                                                                                                   |
| [`5b995591`](https://github.com/NixOS/nixpkgs/commit/5b99559145f841d31bf1b2c5f4c038aa86cf875c) | `` discord-ptb: 0.0.154 -> 0.0.156 ``                                                                                                      |
| [`0ec1eaaa`](https://github.com/NixOS/nixpkgs/commit/0ec1eaaa7c37308b781c8708470cc5885025caff) | `` discord: 0.0.103 -> 0.0.104 ``                                                                                                          |
| [`13e4e7c9`](https://github.com/NixOS/nixpkgs/commit/13e4e7c9e38065ce0321391847db216c3cf4aefb) | `` nextcloud-spreed-signaling: 2.0.3 -> 2.0.4 ``                                                                                           |
| [`8d2864e9`](https://github.com/NixOS/nixpkgs/commit/8d2864e9d7faf9b458c0294b41dea161a72b8076) | `` firebird_4: 4.0.5 -> 4.0.6 ``                                                                                                           |
| [`2ec2773f`](https://github.com/NixOS/nixpkgs/commit/2ec2773fad7ffb9f54726802ab780ed1ecc6133a) | `` alt-tab-macos: 7.26.0 -> 7.27.0 ``                                                                                                      |
| [`4d53240d`](https://github.com/NixOS/nixpkgs/commit/4d53240ddfc94683f327ed90efa8eb16c104ed09) | `` linux_xanmod_latest: 6.15.9 -> 6.15.10 ``                                                                                               |
| [`22953608`](https://github.com/NixOS/nixpkgs/commit/22953608d53ee46a6e27c565e03fbdc27c0383e2) | `` linux_xanmod: 6.12.41 -> 6.12.42 ``                                                                                                     |
| [`e8af78d5`](https://github.com/NixOS/nixpkgs/commit/e8af78d5ea2908ede099bcda5a26dfba9235e18b) | `` radicle-httpd: 0.19.1 → 0.20.0 ``                                                                                                       |
| [`0010ca6d`](https://github.com/NixOS/nixpkgs/commit/0010ca6d14dfe295d7e30aa5751d781d64f3e2cb) | `` linuxKernel.kernels.linux_zen: 6.16 -> 6.16.1 ``                                                                                        |
| [`d6798c78`](https://github.com/NixOS/nixpkgs/commit/d6798c78a44c783560ab97bc3c48f1fc09db150a) | `` imagemagick: 7.1.2-0 -> 7.1.2-1 ``                                                                                                      |
| [`f4442aac`](https://github.com/NixOS/nixpkgs/commit/f4442aaca3f1a332e347dfdb504d20ef11edb12a) | `` slskd: 0.23.1 -> 0.23.2 ``                                                                                                              |
| [`30cdb644`](https://github.com/NixOS/nixpkgs/commit/30cdb644fee9c2c5aff31b2a40e55fd0c37ab5c7) | `` librenms: apply patch for CVE-2025-54238 ``                                                                                             |
| [`934b6eaa`](https://github.com/NixOS/nixpkgs/commit/934b6eaa0742b5f7981ff6036f341ea3ecd91622) | `` llvmPackages_git: 22.0.0-unstable-2025-08-03 -> 22.0.0-unstable-2025-08-17 ``                                                           |
| [`cad5504e`](https://github.com/NixOS/nixpkgs/commit/cad5504e619ce1ba328887ed8d0ec3005441e155) | `` minizinc: 2.9.2 -> 2.9.3 ``                                                                                                             |
| [`a4ebac8b`](https://github.com/NixOS/nixpkgs/commit/a4ebac8bc4cff7e8371ff09f50a8941d4849e0d3) | `` androidenv: apply meta to Android fetchurl calls ``                                                                                     |
| [`05e959a2`](https://github.com/NixOS/nixpkgs/commit/05e959a290f4c2577160ea1fc86c61f0c1e97d56) | `` androidenv: ndk: 28.1.13356709 -> 28.2.13676358; cmake: 4.0.2 -> 4.1.0; platform-tools: 35.0.2 -> 36.0.0; emulator: 35.6.9 -> 36.1.9 `` |
| [`69266e4a`](https://github.com/NixOS/nixpkgs/commit/69266e4a459bb64bdcceae1979de68a901c9d939) | `` androidenv: make test suite version track repo.json hash ``                                                                             |
| [`80e5bedb`](https://github.com/NixOS/nixpkgs/commit/80e5bedba028506dc75e18d969b3c075ca3f097c) | `` qdigidoc: 4.7.0 -> 4.8.0 ``                                                                                                             |
| [`b5397846`](https://github.com/NixOS/nixpkgs/commit/b53978464eba15376a1d728bc12b9f8e9b272415) | `` libdigidocpp: fix INTERFACE_INCLUDE_DIRECTORIES path in cmake file ``                                                                   |
| [`5162a7df`](https://github.com/NixOS/nixpkgs/commit/5162a7df16d5bccbf848d1cd488cbb3d8caf900e) | `` libdigidocpp: drop patchelf workaround ``                                                                                               |
| [`41a219db`](https://github.com/NixOS/nixpkgs/commit/41a219dba0b92376843212767f126311e417a240) | `` libdigidocpp: use fetchFromGitHub ``                                                                                                    |
| [`e452c19f`](https://github.com/NixOS/nixpkgs/commit/e452c19f74538438545498b959197fb8cc598fff) | `` libdigidocpp: 4.1.0 -> 4.2.0 ``                                                                                                         |