### PR TITLE
chore(flake/nur): `da0127fe` -> `d8aaa570`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755621960,
-        "narHash": "sha256-gPReKgHYrlS4HvT7VHho7OzEHDel0ftp579hg42uvjA=",
+        "lastModified": 1755660525,
+        "narHash": "sha256-3tvDDrT8nIveE0PfhpedCdjbFw1SicqW1PxFglF1aog=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "da0127fe69456adfee373d5671401e16f502ff00",
+        "rev": "d8aaa57084bb4632800da93c99236be6b121e6b9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d8aaa570`](https://github.com/nix-community/NUR/commit/d8aaa57084bb4632800da93c99236be6b121e6b9) | `` automatic update `` |
| [`11c1645c`](https://github.com/nix-community/NUR/commit/11c1645c73372d014091a1eadd791a4e0b58e67c) | `` automatic update `` |
| [`a0372431`](https://github.com/nix-community/NUR/commit/a037243103e9aee912ad3b5c73d76371fe2a5983) | `` automatic update `` |
| [`53448dd8`](https://github.com/nix-community/NUR/commit/53448dd855b6fd4e320380f5b283f29ce4a2e0dd) | `` automatic update `` |
| [`9dfde72c`](https://github.com/nix-community/NUR/commit/9dfde72c128369eea89f370d8b46ce1fd14d8f8e) | `` automatic update `` |
| [`61336c89`](https://github.com/nix-community/NUR/commit/61336c89afcd2d1dc0f0c587bef0feb667c7918d) | `` automatic update `` |
| [`d76df8db`](https://github.com/nix-community/NUR/commit/d76df8db296746d1f155c9c1b93ce6d8891a0535) | `` automatic update `` |
| [`3e82dc5d`](https://github.com/nix-community/NUR/commit/3e82dc5daac83381ac7dd68f1af6602e92b6ae35) | `` automatic update `` |
| [`37aecf9f`](https://github.com/nix-community/NUR/commit/37aecf9f94568bff35e45ae3e9d0812a1b1c9b21) | `` automatic update `` |
| [`348e15eb`](https://github.com/nix-community/NUR/commit/348e15ebd175b7881c4b3a7e4d4ca1dda9eb40f3) | `` automatic update `` |
| [`c7b87380`](https://github.com/nix-community/NUR/commit/c7b87380a48999a9a7cb5d0da035fd69ed06832f) | `` automatic update `` |
| [`366bf47e`](https://github.com/nix-community/NUR/commit/366bf47eeda86edef3fdb437f4c7d7fbb36853d5) | `` automatic update `` |