### PR TITLE
chore(flake/nur): `d8aaa570` -> `356a2e67`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755660525,
-        "narHash": "sha256-3tvDDrT8nIveE0PfhpedCdjbFw1SicqW1PxFglF1aog=",
+        "lastModified": 1755669413,
+        "narHash": "sha256-jLRuJYk0zNetnbL7DlKLeg2/AxxxVRZwCAUk3SOXTYk=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "d8aaa57084bb4632800da93c99236be6b121e6b9",
+        "rev": "356a2e676aeb68754bf5602998df44ca931904c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`356a2e67`](https://github.com/nix-community/NUR/commit/356a2e676aeb68754bf5602998df44ca931904c8) | `` automatic update `` |
| [`56396d69`](https://github.com/nix-community/NUR/commit/56396d69a38d68bb568f6ed3a266b5c2cd3106ca) | `` automatic update `` |
| [`79dac39b`](https://github.com/nix-community/NUR/commit/79dac39b32b18a66975332918b0b5e7cf8061c92) | `` automatic update `` |
| [`ac0182ca`](https://github.com/nix-community/NUR/commit/ac0182ca4dd752bf92fd3dc7433c8eb04eb414cd) | `` automatic update `` |