### PR TITLE
chore(flake/nur): `356a2e67` -> `aaeb1973`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1755669413,
-        "narHash": "sha256-jLRuJYk0zNetnbL7DlKLeg2/AxxxVRZwCAUk3SOXTYk=",
+        "lastModified": 1755679870,
+        "narHash": "sha256-Yx4vi56z6xHuVYMWfi7vRo3VgSJoP5v4l5x2TpT/yZ8=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "356a2e676aeb68754bf5602998df44ca931904c8",
+        "rev": "aaeb19738b45aa60d35d5c1457dd82c327d2798e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`aaeb1973`](https://github.com/nix-community/NUR/commit/aaeb19738b45aa60d35d5c1457dd82c327d2798e) | `` automatic update `` |
| [`a8f48b04`](https://github.com/nix-community/NUR/commit/a8f48b041f9464ae0dd10f61b325a5a13221d8ff) | `` automatic update `` |
| [`02bfe0b4`](https://github.com/nix-community/NUR/commit/02bfe0b4b62a2f172129b7c60fd20599e0a73091) | `` automatic update `` |
| [`1c5b78dc`](https://github.com/nix-community/NUR/commit/1c5b78dc2716783f8301f621080b328f9e102342) | `` automatic update `` |